### PR TITLE
feat: add custom PHPStan rules for v0.2.0

### DIFF
--- a/.github/workflows/validate-conventional-commits.yml
+++ b/.github/workflows/validate-conventional-commits.yml
@@ -32,7 +32,7 @@ jobs:
                       MSG=$(echo "$line" | cut -d' ' -f2-)
 
                       # Skip merge commits
-                      if [[ "$MSG" =~ ^Merge\ ]]; then
+                      if [[ "$MSG" == Merge* ]]; then
                           continue
                       fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - Unreleased
+
+### Added
+
+- Bundle third-party PHPStan extensions as direct dependencies
+  (`phpstan-strict-rules`, `phpstan-deprecation-rules`, `phpstan-wordpress`, `phpstan-no-private`)
+- DisallowQueryPostsRule: flag `query_posts()` usage
+- PostTypeNameLengthRule: flag `register_post_type()` names exceeding 20 characters
+- TaxonomyNameLengthRule: flag `register_taxonomy()` names exceeding 32 characters
+- TransientExpirationRule: flag `set_transient()` without expiration
+- PreSerializedDataRule: flag pre-serialized data passed to WP storage functions
+- PreEncodedJsonDataRule: flag pre-encoded JSON data passed to WP storage functions
+- NoDynamicCodeExecutionRule: flag `create_function()`, `assert()` with strings, `preg_replace()` with `/e`
+- NoEvalRule: flag `eval()` usage
+- UnsafeUnserializeRule: flag `unserialize()` without `allowed_classes`
+- RemoteRequestTimeoutRule: flag `wp_remote_*` calls without explicit timeout
+- NoHtmlDomParsingRule, NoHtmlDomParsingFuncCallRule, NoHtmlDomParsingNewRule: flag non-WP HTML parsing
+- NoConcatenationInTranslationRule: flag string concatenation in translation functions
+- NoBlanketSuppressionRule: flag `phpcs:disable`/`phpcs:ignore`/`@phpstan-ignore` without specific rules
+- SerializedStringType and JsonEncodedStringType branded types for data-flow tracking
+- SerializeReturnTypeExtension and JsonEncodeReturnTypeExtension type extensions
+
 ## [0.1.0] - Unreleased
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,11 +25,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - NoConcatenationInTranslationRule: flag string concatenation in translation functions
 - NoBlanketSuppressionRule: flag `phpcs:disable`/`phpcs:ignore`/`@phpstan-ignore` without specific rules
 
+- SerializedStringType and JsonEncodedStringType branded types for data-flow tracking
+- SerializeReturnTypeExtension and JsonEncodeReturnTypeExtension type extensions
+
 ### Fixed
 
 - Bash syntax error in commit validation workflow (`^Merge\ ` regex)
-- SerializedStringType and JsonEncodedStringType branded types for data-flow tracking
-- SerializeReturnTypeExtension and JsonEncodeReturnTypeExtension type extensions
 
 ## [0.1.0] - Unreleased
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - NoHtmlDomParsingRule, NoHtmlDomParsingFuncCallRule, NoHtmlDomParsingNewRule: flag non-WP HTML parsing
 - NoConcatenationInTranslationRule: flag string concatenation in translation functions
 - NoBlanketSuppressionRule: flag `phpcs:disable`/`phpcs:ignore`/`@phpstan-ignore` without specific rules
+
+### Fixed
+
+- Bash syntax error in commit validation workflow (`^Merge\ ` regex)
 - SerializedStringType and JsonEncodedStringType branded types for data-flow tracking
 - SerializeReturnTypeExtension and JsonEncodeReturnTypeExtension type extensions
 

--- a/README.md
+++ b/README.md
@@ -30,9 +30,32 @@ includes:
 
 ## What's Included
 
+### Bundled Extensions
+
+This package automatically includes:
+
+- [phpstan-strict-rules](https://github.com/phpstan/phpstan-strict-rules)
+- [phpstan-deprecation-rules](https://github.com/phpstan/phpstan-deprecation-rules)
+- [phpstan-wordpress](https://github.com/szepeviktor/phpstan-wordpress)
+- [phpstan-no-private](https://github.com/swissspidy/phpstan-no-private)
+
 ### Custom Rules
 
-*Rules will be added as the package evolves.*
+| Rule | Category | What it detects |
+|------|----------|-----------------|
+| DisallowQueryPostsRule | wp-api | `query_posts()` usage |
+| PostTypeNameLengthRule | wp-api | `register_post_type()` name > 20 chars |
+| TaxonomyNameLengthRule | wp-api | `register_taxonomy()` name > 32 chars |
+| TransientExpirationRule | wp-api | `set_transient()` without expiration |
+| RemoteRequestTimeoutRule | wp-api | `wp_remote_*` without explicit timeout |
+| PreSerializedDataRule | data-integrity | Pre-serialized data in WP storage functions |
+| PreEncodedJsonDataRule | data-integrity | Pre-encoded JSON in WP storage functions |
+| NoDynamicCodeExecutionRule | security | `create_function()`, `assert()` with string, `preg_replace()` with `/e` |
+| NoEvalRule | security | `eval()` usage |
+| UnsafeUnserializeRule | security | `unserialize()` without `allowed_classes` |
+| NoHtmlDomParsingRule | code-quality | `DOMDocument::loadHTML`, tidy functions, `Masterminds\HTML5` |
+| NoConcatenationInTranslationRule | i18n | String concatenation inside `__()`, `_e()`, etc. |
+| NoBlanketSuppressionRule | code-quality | `phpcs:disable`/`phpcs:ignore`/`@phpstan-ignore` without specific rules |
 
 ## Development
 

--- a/composer.json
+++ b/composer.json
@@ -22,14 +22,16 @@
     ],
     "require": {
         "php": ">=8.1",
-        "phpstan/phpstan": "^2.0"
+        "phpstan/phpstan": "^2.0",
+        "phpstan/phpstan-deprecation-rules": "^2.0",
+        "phpstan/phpstan-strict-rules": "^2.0",
+        "swissspidy/phpstan-no-private": "^1.0",
+        "szepeviktor/phpstan-wordpress": "^2.0"
     },
     "require-dev": {
         "apermo/apermo-coding-standards": "^2.0",
         "php-stubs/wordpress-stubs": "^6.0",
-        "phpstan/phpstan-strict-rules": "^2.0",
-        "phpunit/phpunit": "^11.0",
-        "szepeviktor/phpstan-wordpress": "^2.0"
+        "phpunit/phpunit": "^11.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,6 @@
     },
     "require-dev": {
         "apermo/apermo-coding-standards": "^2.0",
-        "php-stubs/wordpress-stubs": "^6.0",
         "phpunit/phpunit": "^11.0"
     },
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9ca64f698409b9d1646c17e05f5a6eb7",
+    "content-hash": "1fb7f12fca6486756124c89be519ada3",
     "packages": [
         {
             "name": "php-stubs/wordpress-stubs",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,60 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5fa589dbad3c2f74d70c1ede1994da2a",
+    "content-hash": "9ca64f698409b9d1646c17e05f5a6eb7",
     "packages": [
+        {
+            "name": "php-stubs/wordpress-stubs",
+            "version": "v6.9.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-stubs/wordpress-stubs.git",
+                "reference": "f12220f303e0d7c0844c0e5e957b0c3cee48d2f7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/f12220f303e0d7c0844c0e5e957b0c3cee48d2f7",
+                "reference": "f12220f303e0d7c0844c0e5e957b0c3cee48d2f7",
+                "shasum": ""
+            },
+            "conflict": {
+                "phpdocumentor/reflection-docblock": "5.6.1"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "nikic/php-parser": "^5.5",
+                "php": "^7.4 || ^8.0",
+                "php-stubs/generator": "^0.8.3",
+                "phpdocumentor/reflection-docblock": "^6.0",
+                "phpstan/phpstan": "^2.1",
+                "phpunit/phpunit": "^9.5",
+                "symfony/polyfill-php80": "*",
+                "szepeviktor/phpcs-psr-12-neutron-hybrid-ruleset": "^1.1.1",
+                "wp-coding-standards/wpcs": "3.1.0 as 2.3.0"
+            },
+            "suggest": {
+                "paragonie/sodium_compat": "Pure PHP implementation of libsodium",
+                "symfony/polyfill-php80": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+                "szepeviktor/phpstan-wordpress": "WordPress extensions for PHPStan"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "WordPress function and class declaration stubs for static analysis.",
+            "homepage": "https://github.com/php-stubs/wordpress-stubs",
+            "keywords": [
+                "PHPStan",
+                "static analysis",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/php-stubs/wordpress-stubs/issues",
+                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.9.1"
+            },
+            "time": "2026-02-03T19:29:21+00:00"
+        },
         {
             "name": "phpstan/phpstan",
             "version": "2.1.40",
@@ -58,6 +110,222 @@
                 }
             ],
             "time": "2026-02-23T15:04:35+00:00"
+        },
+        {
+            "name": "phpstan/phpstan-deprecation-rules",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan-deprecation-rules.git",
+                "reference": "6b5571001a7f04fa0422254c30a0017ec2f2cacc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan-deprecation-rules/zipball/6b5571001a7f04fa0422254c30a0017ec2f2cacc",
+                "reference": "6b5571001a7f04fa0422254c30a0017ec2f2cacc",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0",
+                "phpstan/phpstan": "^2.1.39"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.6"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "rules.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan rules for detecting usage of deprecated classes, methods, properties, constants and traits.",
+            "keywords": [
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/phpstan/phpstan-deprecation-rules/issues",
+                "source": "https://github.com/phpstan/phpstan-deprecation-rules/tree/2.0.4"
+            },
+            "time": "2026-02-09T13:21:14+00:00"
+        },
+        {
+            "name": "phpstan/phpstan-strict-rules",
+            "version": "2.0.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan-strict-rules.git",
+                "reference": "1aba28b697c1e3b6bbec8a1725f8b11b6d3e5a5f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan-strict-rules/zipball/1aba28b697c1e3b6bbec8a1725f8b11b6d3e5a5f",
+                "reference": "1aba28b697c1e3b6bbec8a1725f8b11b6d3e5a5f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0",
+                "phpstan/phpstan": "^2.1.39"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/phpstan-deprecation-rules": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.6"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "rules.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Extra strict and opinionated rules for PHPStan",
+            "keywords": [
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/phpstan/phpstan-strict-rules/issues",
+                "source": "https://github.com/phpstan/phpstan-strict-rules/tree/2.0.10"
+            },
+            "time": "2026-02-11T14:17:32+00:00"
+        },
+        {
+            "name": "swissspidy/phpstan-no-private",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/swissspidy/phpstan-no-private.git",
+                "reference": "559cb0e8d092df7314ed4254db83db0427440af2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/swissspidy/phpstan-no-private/zipball/559cb0e8d092df7314ed4254db83db0427440af2",
+                "reference": "559cb0e8d092df7314ed4254db83db0427440af2",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0",
+                "phpstan/phpstan": "^2.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0.0",
+                "nikic/php-parser": "^v5.3.1",
+                "php-parallel-lint/php-parallel-lint": "^1.4",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^9.5",
+                "slevomat/coding-standard": "^8.8.0",
+                "squizlabs/php_codesniffer": "^3.5.3"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "rules.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Swissspidy\\PHPStan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan rules for detecting usage of pseudo-private functions, classes, and methods.",
+            "support": {
+                "issues": "https://github.com/swissspidy/phpstan-no-private/issues",
+                "source": "https://github.com/swissspidy/phpstan-no-private/tree/v1.0.0"
+            },
+            "time": "2024-11-11T11:04:45+00:00"
+        },
+        {
+            "name": "szepeviktor/phpstan-wordpress",
+            "version": "v2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/szepeviktor/phpstan-wordpress.git",
+                "reference": "aa722f037b2d034828cd6c55ebe9e5c74961927e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/szepeviktor/phpstan-wordpress/zipball/aa722f037b2d034828cd6c55ebe9e5c74961927e",
+                "reference": "aa722f037b2d034828cd6c55ebe9e5c74961927e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0",
+                "php-stubs/wordpress-stubs": "^6.6.2",
+                "phpstan/phpstan": "^2.0"
+            },
+            "require-dev": {
+                "composer/composer": "^2.1.14",
+                "composer/semver": "^3.4",
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.1",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^9.0",
+                "szepeviktor/phpcs-psr-12-neutron-hybrid-ruleset": "^1.0",
+                "wp-coding-standards/wpcs": "3.1.0 as 2.3.0"
+            },
+            "suggest": {
+                "swissspidy/phpstan-no-private": "Detect usage of internal core functions, classes and methods"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "SzepeViktor\\PHPStan\\WordPress\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "WordPress extensions for PHPStan",
+            "keywords": [
+                "PHPStan",
+                "code analyse",
+                "code analysis",
+                "static analysis",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/szepeviktor/phpstan-wordpress/issues",
+                "source": "https://github.com/szepeviktor/phpstan-wordpress/tree/v2.0.3"
+            },
+            "time": "2025-09-14T02:58:22+00:00"
         }
     ],
     "packages-dev": [
@@ -668,58 +936,6 @@
             "time": "2024-03-27T12:14:49+00:00"
         },
         {
-            "name": "php-stubs/wordpress-stubs",
-            "version": "v6.9.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-stubs/wordpress-stubs.git",
-                "reference": "f12220f303e0d7c0844c0e5e957b0c3cee48d2f7"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/f12220f303e0d7c0844c0e5e957b0c3cee48d2f7",
-                "reference": "f12220f303e0d7c0844c0e5e957b0c3cee48d2f7",
-                "shasum": ""
-            },
-            "conflict": {
-                "phpdocumentor/reflection-docblock": "5.6.1"
-            },
-            "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
-                "nikic/php-parser": "^5.5",
-                "php": "^7.4 || ^8.0",
-                "php-stubs/generator": "^0.8.3",
-                "phpdocumentor/reflection-docblock": "^6.0",
-                "phpstan/phpstan": "^2.1",
-                "phpunit/phpunit": "^9.5",
-                "symfony/polyfill-php80": "*",
-                "szepeviktor/phpcs-psr-12-neutron-hybrid-ruleset": "^1.1.1",
-                "wp-coding-standards/wpcs": "3.1.0 as 2.3.0"
-            },
-            "suggest": {
-                "paragonie/sodium_compat": "Pure PHP implementation of libsodium",
-                "symfony/polyfill-php80": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
-                "szepeviktor/phpstan-wordpress": "WordPress extensions for PHPStan"
-            },
-            "type": "library",
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "WordPress function and class declaration stubs for static analysis.",
-            "homepage": "https://github.com/php-stubs/wordpress-stubs",
-            "keywords": [
-                "PHPStan",
-                "static analysis",
-                "wordpress"
-            ],
-            "support": {
-                "issues": "https://github.com/php-stubs/wordpress-stubs/issues",
-                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.9.1"
-            },
-            "time": "2026-02-03T19:29:21+00:00"
-        },
-        {
             "name": "phpcompatibility/php-compatibility",
             "version": "9.3.5",
             "source": {
@@ -1153,57 +1369,6 @@
                 "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.2"
             },
             "time": "2026-01-25T14:56:51+00:00"
-        },
-        {
-            "name": "phpstan/phpstan-strict-rules",
-            "version": "2.0.10",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpstan/phpstan-strict-rules.git",
-                "reference": "1aba28b697c1e3b6bbec8a1725f8b11b6d3e5a5f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-strict-rules/zipball/1aba28b697c1e3b6bbec8a1725f8b11b6d3e5a5f",
-                "reference": "1aba28b697c1e3b6bbec8a1725f8b11b6d3e5a5f",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.4 || ^8.0",
-                "phpstan/phpstan": "^2.1.39"
-            },
-            "require-dev": {
-                "php-parallel-lint/php-parallel-lint": "^1.2",
-                "phpstan/phpstan-deprecation-rules": "^2.0",
-                "phpstan/phpstan-phpunit": "^2.0",
-                "phpunit/phpunit": "^9.6"
-            },
-            "type": "phpstan-extension",
-            "extra": {
-                "phpstan": {
-                    "includes": [
-                        "rules.neon"
-                    ]
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "PHPStan\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "Extra strict and opinionated rules for PHPStan",
-            "keywords": [
-                "static analysis"
-            ],
-            "support": {
-                "issues": "https://github.com/phpstan/phpstan-strict-rules/issues",
-                "source": "https://github.com/phpstan/phpstan-strict-rules/tree/2.0.10"
-            },
-            "time": "2026-02-11T14:17:32+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -2899,69 +3064,6 @@
                 }
             ],
             "time": "2024-10-20T05:08:20+00:00"
-        },
-        {
-            "name": "szepeviktor/phpstan-wordpress",
-            "version": "v2.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/szepeviktor/phpstan-wordpress.git",
-                "reference": "aa722f037b2d034828cd6c55ebe9e5c74961927e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/szepeviktor/phpstan-wordpress/zipball/aa722f037b2d034828cd6c55ebe9e5c74961927e",
-                "reference": "aa722f037b2d034828cd6c55ebe9e5c74961927e",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.4 || ^8.0",
-                "php-stubs/wordpress-stubs": "^6.6.2",
-                "phpstan/phpstan": "^2.0"
-            },
-            "require-dev": {
-                "composer/composer": "^2.1.14",
-                "composer/semver": "^3.4",
-                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
-                "php-parallel-lint/php-parallel-lint": "^1.1",
-                "phpstan/phpstan-strict-rules": "^2.0",
-                "phpunit/phpunit": "^9.0",
-                "szepeviktor/phpcs-psr-12-neutron-hybrid-ruleset": "^1.0",
-                "wp-coding-standards/wpcs": "3.1.0 as 2.3.0"
-            },
-            "suggest": {
-                "swissspidy/phpstan-no-private": "Detect usage of internal core functions, classes and methods"
-            },
-            "type": "phpstan-extension",
-            "extra": {
-                "phpstan": {
-                    "includes": [
-                        "extension.neon"
-                    ]
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "SzepeViktor\\PHPStan\\WordPress\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "WordPress extensions for PHPStan",
-            "keywords": [
-                "PHPStan",
-                "code analyse",
-                "code analysis",
-                "static analysis",
-                "wordpress"
-            ],
-            "support": {
-                "issues": "https://github.com/szepeviktor/phpstan-wordpress/issues",
-                "source": "https://github.com/szepeviktor/phpstan-wordpress/tree/v2.0.3"
-            },
-            "time": "2025-09-14T02:58:22+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,6 @@
 includes:
     - vendor/phpstan/phpstan-strict-rules/rules.neon
+    - vendor/phpstan/phpstan-deprecation-rules/rules.neon
 
 parameters:
     level: 6

--- a/rules.neon
+++ b/rules.neon
@@ -14,6 +14,9 @@ rules:
     - Apermo\PhpStanWordPressRules\Rules\DisallowQueryPostsRule
     - Apermo\PhpStanWordPressRules\Rules\NoDynamicCodeExecutionRule
     - Apermo\PhpStanWordPressRules\Rules\NoEvalRule
+    - Apermo\PhpStanWordPressRules\Rules\NoHtmlDomParsingFuncCallRule
+    - Apermo\PhpStanWordPressRules\Rules\NoHtmlDomParsingNewRule
+    - Apermo\PhpStanWordPressRules\Rules\NoHtmlDomParsingRule
     - Apermo\PhpStanWordPressRules\Rules\PostTypeNameLengthRule
     - Apermo\PhpStanWordPressRules\Rules\PreEncodedJsonDataRule
     - Apermo\PhpStanWordPressRules\Rules\PreSerializedDataRule

--- a/rules.neon
+++ b/rules.neon
@@ -1,9 +1,19 @@
 parameters:
 
 services:
+    -
+        class: Apermo\PhpStanWordPressRules\Extensions\SerializeReturnTypeExtension
+        tags:
+            - phpstan.broker.dynamicFunctionReturnTypeExtension
+    -
+        class: Apermo\PhpStanWordPressRules\Extensions\JsonEncodeReturnTypeExtension
+        tags:
+            - phpstan.broker.dynamicFunctionReturnTypeExtension
 
 rules:
     - Apermo\PhpStanWordPressRules\Rules\DisallowQueryPostsRule
     - Apermo\PhpStanWordPressRules\Rules\PostTypeNameLengthRule
+    - Apermo\PhpStanWordPressRules\Rules\PreEncodedJsonDataRule
+    - Apermo\PhpStanWordPressRules\Rules\PreSerializedDataRule
     - Apermo\PhpStanWordPressRules\Rules\TaxonomyNameLengthRule
     - Apermo\PhpStanWordPressRules\Rules\TransientExpirationRule

--- a/rules.neon
+++ b/rules.neon
@@ -12,6 +12,8 @@ services:
 
 rules:
     - Apermo\PhpStanWordPressRules\Rules\DisallowQueryPostsRule
+    - Apermo\PhpStanWordPressRules\Rules\NoDynamicCodeExecutionRule
+    - Apermo\PhpStanWordPressRules\Rules\NoEvalRule
     - Apermo\PhpStanWordPressRules\Rules\PostTypeNameLengthRule
     - Apermo\PhpStanWordPressRules\Rules\PreEncodedJsonDataRule
     - Apermo\PhpStanWordPressRules\Rules\PreSerializedDataRule

--- a/rules.neon
+++ b/rules.neon
@@ -6,3 +6,4 @@ rules:
     - Apermo\PhpStanWordPressRules\Rules\DisallowQueryPostsRule
     - Apermo\PhpStanWordPressRules\Rules\PostTypeNameLengthRule
     - Apermo\PhpStanWordPressRules\Rules\TaxonomyNameLengthRule
+    - Apermo\PhpStanWordPressRules\Rules\TransientExpirationRule

--- a/rules.neon
+++ b/rules.neon
@@ -12,6 +12,7 @@ services:
 
 rules:
     - Apermo\PhpStanWordPressRules\Rules\DisallowQueryPostsRule
+    - Apermo\PhpStanWordPressRules\Rules\NoBlanketSuppressionRule
     - Apermo\PhpStanWordPressRules\Rules\NoConcatenationInTranslationRule
     - Apermo\PhpStanWordPressRules\Rules\NoDynamicCodeExecutionRule
     - Apermo\PhpStanWordPressRules\Rules\NoEvalRule

--- a/rules.neon
+++ b/rules.neon
@@ -12,6 +12,7 @@ services:
 
 rules:
     - Apermo\PhpStanWordPressRules\Rules\DisallowQueryPostsRule
+    - Apermo\PhpStanWordPressRules\Rules\NoConcatenationInTranslationRule
     - Apermo\PhpStanWordPressRules\Rules\NoDynamicCodeExecutionRule
     - Apermo\PhpStanWordPressRules\Rules\NoEvalRule
     - Apermo\PhpStanWordPressRules\Rules\NoHtmlDomParsingFuncCallRule

--- a/rules.neon
+++ b/rules.neon
@@ -17,6 +17,7 @@ rules:
     - Apermo\PhpStanWordPressRules\Rules\PostTypeNameLengthRule
     - Apermo\PhpStanWordPressRules\Rules\PreEncodedJsonDataRule
     - Apermo\PhpStanWordPressRules\Rules\PreSerializedDataRule
+    - Apermo\PhpStanWordPressRules\Rules\RemoteRequestTimeoutRule
     - Apermo\PhpStanWordPressRules\Rules\TaxonomyNameLengthRule
     - Apermo\PhpStanWordPressRules\Rules\TransientExpirationRule
     - Apermo\PhpStanWordPressRules\Rules\UnsafeUnserializeRule

--- a/rules.neon
+++ b/rules.neon
@@ -3,3 +3,4 @@ parameters:
 services:
 
 rules:
+    - Apermo\PhpStanWordPressRules\Rules\DisallowQueryPostsRule

--- a/rules.neon
+++ b/rules.neon
@@ -4,3 +4,5 @@ services:
 
 rules:
     - Apermo\PhpStanWordPressRules\Rules\DisallowQueryPostsRule
+    - Apermo\PhpStanWordPressRules\Rules\PostTypeNameLengthRule
+    - Apermo\PhpStanWordPressRules\Rules\TaxonomyNameLengthRule

--- a/rules.neon
+++ b/rules.neon
@@ -19,3 +19,4 @@ rules:
     - Apermo\PhpStanWordPressRules\Rules\PreSerializedDataRule
     - Apermo\PhpStanWordPressRules\Rules\TaxonomyNameLengthRule
     - Apermo\PhpStanWordPressRules\Rules\TransientExpirationRule
+    - Apermo\PhpStanWordPressRules\Rules\UnsafeUnserializeRule

--- a/src/Constants/WordPressStorageFunctions.php
+++ b/src/Constants/WordPressStorageFunctions.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\PhpStanWordPressRules\Constants;
+
+/**
+ * Shared constant for WordPress storage functions and their value parameter indices.
+ */
+final class WordPressStorageFunctions {
+
+	// phpcs:disable Apermo.DataStructures.ArrayComplexity.TooManyKeysError -- WordPress has many storage functions
+	/**
+	 * WordPress storage functions and the 0-based index of their value parameter.
+	 *
+	 * @var array<string, int>
+	 */
+	public const VALUE_PARAM_INDEX = [
+		'add_option'             => 1,
+		'update_option'          => 1,
+		'add_network_option'     => 2,
+		'update_network_option'  => 2,
+		'add_metadata'           => 3,
+		'update_metadata'        => 3,
+		'update_metadata_by_mid' => 2,
+		'add_post_meta'          => 2,
+		'update_post_meta'       => 2,
+		'add_user_meta'          => 2,
+		'update_user_meta'       => 2,
+		'add_comment_meta'       => 2,
+		'update_comment_meta'    => 2,
+		'add_term_meta'          => 2,
+		'update_term_meta'       => 2,
+		'add_site_meta'          => 2,
+		'update_site_meta'       => 2,
+		'set_transient'          => 1,
+		'set_site_transient'     => 1,
+	];
+	// phpcs:enable Apermo.DataStructures.ArrayComplexity.TooManyKeysError
+}

--- a/src/Extensions/JsonEncodeReturnTypeExtension.php
+++ b/src/Extensions/JsonEncodeReturnTypeExtension.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\PhpStanWordPressRules\Extensions;
+
+use Apermo\PhpStanWordPressRules\Type\JsonEncodedStringType;
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Type\DynamicFunctionReturnTypeExtension;
+use PHPStan\Type\Type;
+
+/**
+ * Marks json_encode() and wp_json_encode() return values as JsonEncodedStringType.
+ */
+final class JsonEncodeReturnTypeExtension implements DynamicFunctionReturnTypeExtension {
+
+	/**
+	 * Checks if this extension handles the given function.
+	 *
+	 * phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase -- PHPStan interface
+	 *
+	 * @param FunctionReflection $functionReflection Function reflection.
+	 * @return bool
+	 */
+	public function isFunctionSupported( FunctionReflection $functionReflection ): bool { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase -- PHPStan interface
+		return in_array(
+			$functionReflection->getName(), // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase -- PHPStan interface
+			[ 'json_encode', 'wp_json_encode' ],
+			true,
+		);
+	}
+
+	/**
+	 * Returns JsonEncodedStringType for tracked function calls.
+	 *
+	 * phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase -- PHPStan interface
+	 *
+	 * @param FunctionReflection $functionReflection Function reflection.
+	 * @param FuncCall           $functionCall       Function call node.
+	 * @param Scope              $scope              Analysis scope.
+	 * @return Type
+	 */
+	public function getTypeFromFunctionCall(
+		FunctionReflection $functionReflection, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase -- PHPStan interface
+		FuncCall $functionCall, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase -- PHPStan interface
+		Scope $scope,
+	): Type {
+		return new JsonEncodedStringType();
+	}
+}

--- a/src/Extensions/JsonEncodeReturnTypeExtension.php
+++ b/src/Extensions/JsonEncodeReturnTypeExtension.php
@@ -8,8 +8,10 @@ use Apermo\PhpStanWordPressRules\Type\JsonEncodedStringType;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\Type;
+use PHPStan\Type\UnionType;
 
 /**
  * Marks json_encode() and wp_json_encode() return values as JsonEncodedStringType.
@@ -47,6 +49,6 @@ final class JsonEncodeReturnTypeExtension implements DynamicFunctionReturnTypeEx
 		FuncCall $functionCall, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase -- PHPStan interface
 		Scope $scope,
 	): Type {
-		return new JsonEncodedStringType();
+		return new UnionType( [ new JsonEncodedStringType(), new ConstantBooleanType( false ) ] );
 	}
 }

--- a/src/Extensions/SerializeReturnTypeExtension.php
+++ b/src/Extensions/SerializeReturnTypeExtension.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\PhpStanWordPressRules\Extensions;
+
+use Apermo\PhpStanWordPressRules\Type\SerializedStringType;
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Type\DynamicFunctionReturnTypeExtension;
+use PHPStan\Type\Type;
+
+/**
+ * Marks serialize() and maybe_serialize() return values as SerializedStringType.
+ */
+final class SerializeReturnTypeExtension implements DynamicFunctionReturnTypeExtension {
+
+	/**
+	 * Checks if this extension handles the given function.
+	 *
+	 * phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase -- PHPStan interface
+	 *
+	 * @param FunctionReflection $functionReflection Function reflection.
+	 * @return bool
+	 */
+	public function isFunctionSupported( FunctionReflection $functionReflection ): bool { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase -- PHPStan interface
+		return in_array(
+			$functionReflection->getName(), // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase -- PHPStan interface
+			[ 'serialize', 'maybe_serialize' ],
+			true,
+		);
+	}
+
+	/**
+	 * Returns SerializedStringType for tracked function calls.
+	 *
+	 * phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase -- PHPStan interface
+	 *
+	 * @param FunctionReflection $functionReflection Function reflection.
+	 * @param FuncCall           $functionCall       Function call node.
+	 * @param Scope              $scope              Analysis scope.
+	 * @return Type
+	 */
+	public function getTypeFromFunctionCall(
+		FunctionReflection $functionReflection, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase -- PHPStan interface
+		FuncCall $functionCall, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase -- PHPStan interface
+		Scope $scope,
+	): Type {
+		return new SerializedStringType();
+	}
+}

--- a/src/Rules/DisallowQueryPostsRule.php
+++ b/src/Rules/DisallowQueryPostsRule.php
@@ -12,29 +12,41 @@ use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 
 /**
+ * Flags usage of query_posts() which modifies the main query global.
+ *
  * @implements Rule<FuncCall>
  */
-final class DisallowQueryPostsRule implements Rule
-{
-	public function getNodeType(): string
-	{
+final class DisallowQueryPostsRule implements Rule {
+
+	/**
+	 * Returns the node type this rule processes.
+	 *
+	 * @return class-string<FuncCall>
+	 */
+	public function getNodeType(): string {
 		return FuncCall::class;
 	}
 
-	public function processNode(Node $node, Scope $scope): array
-	{
-		if (!$node->name instanceof Name) {
+	/**
+	 * Processes a function call node.
+	 *
+	 * @param \PhpParser\Node\Expr\FuncCall $node  Function call node.
+	 * @param Scope                         $scope Analysis scope.
+	 * @return list<\PHPStan\Rules\IdentifierRuleError>
+	 */
+	public function processNode( Node $node, Scope $scope ): array { // phpcs:ignore Squiz.Commenting.FunctionComment.IncorrectTypeHint -- Rule interface requires Node
+		if ( ! $node->name instanceof Name ) {
 			return [];
 		}
 
-		if ($node->name->toLowerString() !== 'query_posts') {
+		if ( $node->name->toLowerString() !== 'query_posts' ) {
 			return [];
 		}
 
 		return [
 			RuleErrorBuilder::message(
 				'Do not use query_posts(). Use WP_Query or get_posts() instead.'
-			)->identifier('apermo.disallowQueryPosts')->build(),
+			)->identifier( 'apermo.disallowQueryPosts' )->build(),
 		];
 	}
 }

--- a/src/Rules/DisallowQueryPostsRule.php
+++ b/src/Rules/DisallowQueryPostsRule.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\PhpStanWordPressRules\Rules;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Name;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * @implements Rule<FuncCall>
+ */
+final class DisallowQueryPostsRule implements Rule
+{
+	public function getNodeType(): string
+	{
+		return FuncCall::class;
+	}
+
+	public function processNode(Node $node, Scope $scope): array
+	{
+		if (!$node->name instanceof Name) {
+			return [];
+		}
+
+		if ($node->name->toLowerString() !== 'query_posts') {
+			return [];
+		}
+
+		return [
+			RuleErrorBuilder::message(
+				'Do not use query_posts(). Use WP_Query or get_posts() instead.'
+			)->identifier('apermo.disallowQueryPosts')->build(),
+		];
+	}
+}

--- a/src/Rules/NoBlanketSuppressionRule.php
+++ b/src/Rules/NoBlanketSuppressionRule.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\PhpStanWordPressRules\Rules;
+
+use PhpParser\Comment;
+use PhpParser\Node;
+use PhpParser\Node\Stmt;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * Flags blanket suppression comments that suppress all checks without specifying which rules.
+ *
+ * @implements Rule<Stmt>
+ */
+final class NoBlanketSuppressionRule implements Rule {
+
+	/**
+	 * Returns the node type this rule processes.
+	 *
+	 * @return class-string<Stmt>
+	 */
+	public function getNodeType(): string {
+		return Stmt::class;
+	}
+
+	/**
+	 * Processes a statement node and checks its comments for blanket suppressions.
+	 *
+	 * @param \PhpParser\Node\Stmt $node  Statement node.
+	 * @param Scope                $scope Analysis scope.
+	 * @return list<\PHPStan\Rules\IdentifierRuleError>
+	 */
+	public function processNode( Node $node, Scope $scope ): array { // phpcs:ignore Squiz.Commenting.FunctionComment.IncorrectTypeHint -- Rule interface requires Node
+		$errors = [];
+
+		foreach ( $node->getComments() as $comment ) {
+			if ( $this->is_blanket_suppression( $comment ) ) {
+				$errors[] = RuleErrorBuilder::message(
+					'Blanket suppression is not allowed. Specify which rules to suppress.'
+				)->identifier( 'apermo.noBlanketSuppression' )->line( $comment->getStartLine() )->build();
+			}
+		}
+
+		return $errors;
+	}
+
+	/**
+	 * Checks if a comment is a blanket suppression.
+	 *
+	 * @param Comment $comment Comment to check.
+	 * @return bool
+	 */
+	private function is_blanket_suppression( Comment $comment ): bool {
+		$text = $comment->getText();
+
+		// Strip comment delimiters to get the content.
+		$content = $this->get_comment_content( $text );
+		$content = trim( $content );
+
+		// Blanket phpcs:disable with no rule specified.
+		if ( preg_match( '/^phpcs:disable\s*$/i', $content ) === 1 ) {
+			return true;
+		}
+
+		// phpcs:disable with only a reason, no rule name.
+		if ( preg_match( '/^phpcs:disable\s+--/i', $content ) === 1 ) {
+			return true;
+		}
+
+		// Blanket phpcs:ignore with no rule specified.
+		if ( preg_match( '/^phpcs:ignore\s*$/i', $content ) === 1 ) {
+			return true;
+		}
+
+		// phpcs:ignore with only a reason, no rule name.
+		if ( preg_match( '/^phpcs:ignore\s+--/i', $content ) === 1 ) {
+			return true;
+		}
+
+		// Blanket phpstan ignore-next-line with no rule identifiers.
+		if ( preg_match( '/^@phpstan-ignore-next-line\s*$/i', $content ) === 1 ) {
+			return true;
+		}
+
+		// Blanket phpstan ignore-line with no rule identifiers.
+		if ( preg_match( '/^@phpstan-ignore-line\s*$/i', $content ) === 1 ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Extracts the content from a comment, stripping delimiters.
+	 *
+	 * @param string $text Raw comment text including delimiters.
+	 * @return string
+	 */
+	private function get_comment_content( string $text ): string {
+		// Single-line: // content or # content.
+		if ( str_starts_with( $text, '//' ) ) {
+			return substr( $text, 2 );
+		}
+
+		if ( str_starts_with( $text, '#' ) ) {
+			return substr( $text, 1 );
+		}
+
+		// Multi-line: /* content */ or /** content */.
+		if ( str_starts_with( $text, '/*' ) ) {
+			$inner = substr( $text, 2, -2 );
+
+			// Remove leading * from doc comment lines.
+			$inner = preg_replace( '/^\s*\*\s?/m', '', $inner );
+
+			return $inner ?? '';
+		}
+
+		return $text;
+	}
+}

--- a/src/Rules/NoBlanketSuppressionRule.php
+++ b/src/Rules/NoBlanketSuppressionRule.php
@@ -91,6 +91,11 @@ final class NoBlanketSuppressionRule implements Rule {
 			return true;
 		}
 
+		// Blanket inline phpstan-ignore with no identifiers.
+		if ( preg_match( '/^\x40phpstan-ignore\s*$/i', $content ) === 1 ) {
+			return true;
+		}
+
 		return false;
 	}
 

--- a/src/Rules/NoConcatenationInTranslationRule.php
+++ b/src/Rules/NoConcatenationInTranslationRule.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\PhpStanWordPressRules\Rules;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\BinaryOp\Concat;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\String_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * Flags string concatenation with non-literals inside WordPress translation functions.
+ *
+ * @implements Rule<FuncCall>
+ */
+final class NoConcatenationInTranslationRule implements Rule {
+
+	// phpcs:disable Apermo.DataStructures.ArrayComplexity -- WordPress has many translation functions
+	/**
+	 * Translation functions and which argument positions (0-based) contain translatable strings.
+	 *
+	 * @var array<string, list<int>>
+	 */
+	private const TRANSLATION_FUNCTIONS = [
+		'__' => [ 0 ],
+		'_e' => [ 0 ],
+		'esc_html__' => [ 0 ],
+		'esc_attr__' => [ 0 ],
+		'esc_html_e' => [ 0 ],
+		'esc_attr_e' => [ 0 ],
+		'_x' => [ 0 ],
+		'_ex' => [ 0 ],
+		'_n' => [ 0, 1 ],
+		'_nx' => [ 0, 1 ],
+	];
+	// phpcs:enable Apermo.DataStructures.ArrayComplexity
+
+	/**
+	 * Returns the node type this rule processes.
+	 *
+	 * @return class-string<FuncCall>
+	 */
+	public function getNodeType(): string {
+		return FuncCall::class;
+	}
+
+	/**
+	 * Processes a function call node.
+	 *
+	 * @param \PhpParser\Node\Expr\FuncCall $node  Function call node.
+	 * @param Scope                         $scope Analysis scope.
+	 * @return list<\PHPStan\Rules\IdentifierRuleError>
+	 */
+	public function processNode( Node $node, Scope $scope ): array { // phpcs:ignore Squiz.Commenting.FunctionComment.IncorrectTypeHint -- Rule interface requires Node
+		if ( ! $node->name instanceof Name ) {
+			return [];
+		}
+
+		$function_name = $node->name->toLowerString();
+
+		if ( ! isset( self::TRANSLATION_FUNCTIONS[ $function_name ] ) ) {
+			return [];
+		}
+
+		$args           = $node->getArgs();
+		$string_indices = self::TRANSLATION_FUNCTIONS[ $function_name ];
+		$errors         = [];
+
+		foreach ( $string_indices as $index ) {
+			if ( ! isset( $args[ $index ] ) ) {
+				continue;
+			}
+
+			$arg_value = $args[ $index ]->value;
+
+			if ( ! $arg_value instanceof Concat ) {
+				continue;
+			}
+
+			if ( $this->is_all_string_literals( $arg_value ) ) {
+				continue;
+			}
+
+			$errors[] = RuleErrorBuilder::message(
+				sprintf(
+					'Do not concatenate dynamic values in %s(). Use sprintf() with a translatable format string instead.',
+					$function_name,
+				)
+			)->identifier( 'apermo.noConcatenationInTranslation' )->build();
+		}
+
+		return $errors;
+	}
+
+	/**
+	 * Recursively checks if a Concat expression is composed entirely of string literals.
+	 *
+	 * @param Expr $expr Expression to check.
+	 * @return bool
+	 */
+	private function is_all_string_literals( Expr $expr ): bool {
+		if ( $expr instanceof String_ ) {
+			return true;
+		}
+
+		if ( $expr instanceof Concat ) {
+			return $this->is_all_string_literals( $expr->left )
+				&& $this->is_all_string_literals( $expr->right );
+		}
+
+		return false;
+	}
+}

--- a/src/Rules/NoDynamicCodeExecutionRule.php
+++ b/src/Rules/NoDynamicCodeExecutionRule.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\PhpStanWordPressRules\Rules;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\String_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * Flags dynamic code execution functions like create_function(), assert() with strings, and preg_replace() with /e.
+ *
+ * @implements Rule<FuncCall>
+ */
+final class NoDynamicCodeExecutionRule implements Rule {
+
+	/**
+	 * Returns the node type this rule processes.
+	 *
+	 * @return class-string<FuncCall>
+	 */
+	public function getNodeType(): string {
+		return FuncCall::class;
+	}
+
+	/**
+	 * Processes a function call node.
+	 *
+	 * @param \PhpParser\Node\Expr\FuncCall $node  Function call node.
+	 * @param Scope                         $scope Analysis scope.
+	 * @return list<\PHPStan\Rules\IdentifierRuleError>
+	 */
+	public function processNode( Node $node, Scope $scope ): array { // phpcs:ignore Squiz.Commenting.FunctionComment.IncorrectTypeHint -- Rule interface requires Node
+		if ( ! $node->name instanceof Name ) {
+			return [];
+		}
+
+		$function_name = $node->name->toLowerString();
+
+		if ( $function_name === 'create_function' ) {
+			return [
+				RuleErrorBuilder::message(
+					'Do not use create_function(). Use anonymous functions (closures) instead.'
+				)->identifier( 'apermo.noDynamicCodeExecution' )->build(),
+			];
+		}
+
+		if ( $function_name === 'assert' ) {
+			return $this->check_assert( $node );
+		}
+
+		if ( $function_name === 'preg_replace' ) {
+			return $this->check_preg_replace( $node );
+		}
+
+		return [];
+	}
+
+	/**
+	 * Checks if assert() is called with a string argument.
+	 *
+	 * @param FuncCall $node Function call node.
+	 * @return list<\PHPStan\Rules\IdentifierRuleError>
+	 */
+	private function check_assert( FuncCall $node ): array {
+		$args = $node->getArgs();
+
+		if ( count( $args ) === 0 ) {
+			return [];
+		}
+
+		if ( ! $args[0]->value instanceof String_ ) {
+			return [];
+		}
+
+		return [
+			RuleErrorBuilder::message(
+				'Do not use assert() with a string argument. It evaluates the string as PHP code. Use an expression instead.'
+			)->identifier( 'apermo.noDynamicCodeExecution' )->build(),
+		];
+	}
+
+	/**
+	 * Checks if preg_replace() uses the deprecated e modifier.
+	 *
+	 * @param FuncCall $node Function call node.
+	 * @return list<\PHPStan\Rules\IdentifierRuleError>
+	 */
+	private function check_preg_replace( FuncCall $node ): array {
+		$args = $node->getArgs();
+
+		if ( count( $args ) === 0 ) {
+			return [];
+		}
+
+		if ( ! $args[0]->value instanceof String_ ) {
+			return [];
+		}
+
+		$pattern = $args[0]->value->value;
+
+		if ( ! $this->has_e_modifier( $pattern ) ) {
+			return [];
+		}
+
+		return [
+			RuleErrorBuilder::message(
+				'Do not use preg_replace() with the /e modifier. Use preg_replace_callback() instead.'
+			)->identifier( 'apermo.noDynamicCodeExecution' )->build(),
+		];
+	}
+
+	/**
+	 * Checks if a regex pattern contains the e modifier.
+	 *
+	 * @param string $pattern Regex pattern.
+	 * @return bool
+	 */
+	private function has_e_modifier( string $pattern ): bool {
+		$delimiter = $pattern[0] ?? '';
+
+		if ( $delimiter === '' ) {
+			return false;
+		}
+
+		$last_delimiter_pos = strrpos( $pattern, $delimiter, 1 );
+
+		if ( $last_delimiter_pos === false ) {
+			return false;
+		}
+
+		$modifiers = substr( $pattern, $last_delimiter_pos + 1 );
+
+		return str_contains( $modifiers, 'e' );
+	}
+}

--- a/src/Rules/NoEvalRule.php
+++ b/src/Rules/NoEvalRule.php
@@ -37,7 +37,7 @@ final class NoEvalRule implements Rule {
 		return [
 			RuleErrorBuilder::message(
 				'Do not use eval(). It executes arbitrary PHP code and enables remote code execution.'
-			)->identifier( 'apermo.noDynamicCodeExecution' )->build(),
+			)->identifier( 'apermo.noEval' )->build(),
 		];
 	}
 }

--- a/src/Rules/NoEvalRule.php
+++ b/src/Rules/NoEvalRule.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\PhpStanWordPressRules\Rules;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Eval_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * Flags usage of eval() which executes arbitrary PHP code.
+ *
+ * @implements Rule<Eval_>
+ */
+final class NoEvalRule implements Rule {
+
+	/**
+	 * Returns the node type this rule processes.
+	 *
+	 * @return class-string<Eval_>
+	 */
+	public function getNodeType(): string {
+		return Eval_::class;
+	}
+
+	/**
+	 * Processes an eval node.
+	 *
+	 * @param \PhpParser\Node\Expr\Eval_ $node  Eval expression node.
+	 * @param Scope                      $scope Analysis scope.
+	 * @return list<\PHPStan\Rules\IdentifierRuleError>
+	 */
+	public function processNode( Node $node, Scope $scope ): array { // phpcs:ignore Squiz.Commenting.FunctionComment.IncorrectTypeHint -- Rule interface requires Node
+		return [
+			RuleErrorBuilder::message(
+				'Do not use eval(). It executes arbitrary PHP code and enables remote code execution.'
+			)->identifier( 'apermo.noDynamicCodeExecution' )->build(),
+		];
+	}
+}

--- a/src/Rules/NoHtmlDomParsingFuncCallRule.php
+++ b/src/Rules/NoHtmlDomParsingFuncCallRule.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\PhpStanWordPressRules\Rules;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Name;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * Flags tidy_parse_string() and tidy_parse_file() function calls.
+ *
+ * @implements Rule<FuncCall>
+ */
+final class NoHtmlDomParsingFuncCallRule implements Rule {
+
+	/**
+	 * Banned functions and their error messages.
+	 *
+	 * @var array<string, string>
+	 */
+	private const BANNED_FUNCTIONS = [
+		'tidy_parse_string' => 'Do not use tidy_parse_string(). Use WP_HTML_Tag_Processor or WP_HTML_Processor instead.',
+		'tidy_parse_file'   => 'Do not use tidy_parse_file(). Use WP_HTML_Tag_Processor or WP_HTML_Processor instead.',
+	];
+
+	/**
+	 * Returns the node type this rule processes.
+	 *
+	 * @return class-string<FuncCall>
+	 */
+	public function getNodeType(): string {
+		return FuncCall::class;
+	}
+
+	/**
+	 * Processes a function call node.
+	 *
+	 * @param \PhpParser\Node\Expr\FuncCall $node  Function call node.
+	 * @param Scope                         $scope Analysis scope.
+	 * @return list<\PHPStan\Rules\IdentifierRuleError>
+	 */
+	public function processNode( Node $node, Scope $scope ): array { // phpcs:ignore Squiz.Commenting.FunctionComment.IncorrectTypeHint -- Rule interface requires Node
+		if ( ! $node->name instanceof Name ) {
+			return [];
+		}
+
+		$function_name = $node->name->toLowerString();
+
+		if ( ! isset( self::BANNED_FUNCTIONS[ $function_name ] ) ) {
+			return [];
+		}
+
+		return [
+			RuleErrorBuilder::message( self::BANNED_FUNCTIONS[ $function_name ] )
+				->identifier( 'apermo.noHtmlDomParsing' )->build(),
+		];
+	}
+}

--- a/src/Rules/NoHtmlDomParsingNewRule.php
+++ b/src/Rules/NoHtmlDomParsingNewRule.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\PhpStanWordPressRules\Rules;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Name;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * Flags instantiation of Masterminds\HTML5 which implies non-WP HTML parsing.
+ *
+ * @implements Rule<New_>
+ */
+final class NoHtmlDomParsingNewRule implements Rule {
+
+	/**
+	 * Returns the node type this rule processes.
+	 *
+	 * @return class-string<New_>
+	 */
+	public function getNodeType(): string {
+		return New_::class;
+	}
+
+	/**
+	 * Processes a new expression node.
+	 *
+	 * @param \PhpParser\Node\Expr\New_ $node  New expression node.
+	 * @param Scope                     $scope Analysis scope.
+	 * @return list<\PHPStan\Rules\IdentifierRuleError>
+	 */
+	public function processNode( Node $node, Scope $scope ): array { // phpcs:ignore Squiz.Commenting.FunctionComment.IncorrectTypeHint -- Rule interface requires Node
+		if ( ! $node->class instanceof Name ) {
+			return [];
+		}
+
+		$class_name = $node->class->toString();
+
+		if ( $class_name !== 'Masterminds\\HTML5' && $class_name !== 'HTML5' ) {
+			return [];
+		}
+
+		return [
+			RuleErrorBuilder::message(
+				'Do not use Masterminds\HTML5. Use WP_HTML_Tag_Processor or WP_HTML_Processor instead.'
+			)->identifier( 'apermo.noHtmlDomParsing' )->build(),
+		];
+	}
+}

--- a/src/Rules/NoHtmlDomParsingRule.php
+++ b/src/Rules/NoHtmlDomParsingRule.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\PhpStanWordPressRules\Rules;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * Flags DOMDocument::loadHTML(), loadHTMLFile(), and Tidy::parseString() method calls.
+ *
+ * @implements Rule<MethodCall>
+ */
+final class NoHtmlDomParsingRule implements Rule {
+
+	/**
+	 * Map of class names to their banned method names and error messages.
+	 *
+	 * @var array<string, array<string, string>>
+	 */
+	private const BANNED_METHODS = [
+		'DOMDocument' => [
+			'loadhtml'     => 'Do not use DOMDocument::loadHTML(). Use WP_HTML_Tag_Processor or WP_HTML_Processor instead.',
+			'loadhtmlfile' => 'Do not use DOMDocument::loadHTMLFile(). Use WP_HTML_Tag_Processor or WP_HTML_Processor instead.',
+		],
+		'Tidy'        => [
+			'parsestring' => 'Do not use Tidy::parseString(). Use WP_HTML_Tag_Processor or WP_HTML_Processor instead.',
+		],
+	];
+
+	/**
+	 * Returns the node type this rule processes.
+	 *
+	 * @return class-string<MethodCall>
+	 */
+	public function getNodeType(): string {
+		return MethodCall::class;
+	}
+
+	/**
+	 * Processes a method call node.
+	 *
+	 * @param \PhpParser\Node\Expr\MethodCall $node  Method call node.
+	 * @param Scope                           $scope Analysis scope.
+	 * @return list<\PHPStan\Rules\IdentifierRuleError>
+	 */
+	public function processNode( Node $node, Scope $scope ): array { // phpcs:ignore Squiz.Commenting.FunctionComment.IncorrectTypeHint -- Rule interface requires Node
+		if ( ! $node->name instanceof Identifier ) {
+			return [];
+		}
+
+		$method_name = strtolower( $node->name->name );
+		$caller_type = $scope->getType( $node->var );
+
+		foreach ( self::BANNED_METHODS as $class_name => $methods ) {
+			if ( ! isset( $methods[ $method_name ] ) ) {
+				continue;
+			}
+
+			$class_names = $caller_type->getObjectClassNames();
+
+			foreach ( $class_names as $resolved_class ) {
+				if ( strcasecmp( $resolved_class, $class_name ) === 0 ) {
+					return [
+						RuleErrorBuilder::message( $methods[ $method_name ] )
+							->identifier( 'apermo.noHtmlDomParsing' )->build(),
+					];
+				}
+			}
+		}
+
+		return [];
+	}
+}

--- a/src/Rules/PostTypeNameLengthRule.php
+++ b/src/Rules/PostTypeNameLengthRule.php
@@ -13,42 +13,54 @@ use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 
 /**
+ * Flags register_post_type() calls where the name exceeds 20 characters.
+ *
  * @implements Rule<FuncCall>
  */
-final class PostTypeNameLengthRule implements Rule
-{
+final class PostTypeNameLengthRule implements Rule {
+
 	private const MAX_LENGTH = 20;
 
-	public function getNodeType(): string
-	{
+	/**
+	 * Returns the node type this rule processes.
+	 *
+	 * @return class-string<FuncCall>
+	 */
+	public function getNodeType(): string {
 		return FuncCall::class;
 	}
 
-	public function processNode(Node $node, Scope $scope): array
-	{
-		if (!$node->name instanceof Name) {
+	/**
+	 * Processes a function call node.
+	 *
+	 * @param \PhpParser\Node\Expr\FuncCall $node  Function call node.
+	 * @param Scope                         $scope Analysis scope.
+	 * @return list<\PHPStan\Rules\IdentifierRuleError>
+	 */
+	public function processNode( Node $node, Scope $scope ): array { // phpcs:ignore Squiz.Commenting.FunctionComment.IncorrectTypeHint -- Rule interface requires Node
+		if ( ! $node->name instanceof Name ) {
 			return [];
 		}
 
-		if ($node->name->toLowerString() !== 'register_post_type') {
+		if ( $node->name->toLowerString() !== 'register_post_type' ) {
 			return [];
 		}
 
 		$args = $node->getArgs();
 
-		if ($args === []) {
+		if ( $args === [] ) {
 			return [];
 		}
 
-		$firstArg = $args[0]->value;
+		$first_arg = $args[0]->value;
 
-		if (!$firstArg instanceof String_) {
+		if ( ! $first_arg instanceof String_ ) {
 			return [];
 		}
 
-		$length = strlen($firstArg->value);
+		$length = strlen( $first_arg->value );
 
-		if ($length <= self::MAX_LENGTH) {
+		if ( $length <= self::MAX_LENGTH ) {
 			return [];
 		}
 
@@ -56,11 +68,11 @@ final class PostTypeNameLengthRule implements Rule
 			RuleErrorBuilder::message(
 				sprintf(
 					'Post type name "%s" is %d characters long. WordPress limits post type names to %d characters.',
-					$firstArg->value,
+					$first_arg->value,
 					$length,
 					self::MAX_LENGTH,
 				)
-			)->identifier('apermo.postTypeNameLength')->build(),
+			)->identifier( 'apermo.postTypeNameLength' )->build(),
 		];
 	}
 }

--- a/src/Rules/PostTypeNameLengthRule.php
+++ b/src/Rules/PostTypeNameLengthRule.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\PhpStanWordPressRules\Rules;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\String_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * @implements Rule<FuncCall>
+ */
+final class PostTypeNameLengthRule implements Rule
+{
+	private const MAX_LENGTH = 20;
+
+	public function getNodeType(): string
+	{
+		return FuncCall::class;
+	}
+
+	public function processNode(Node $node, Scope $scope): array
+	{
+		if (!$node->name instanceof Name) {
+			return [];
+		}
+
+		if ($node->name->toLowerString() !== 'register_post_type') {
+			return [];
+		}
+
+		$args = $node->getArgs();
+
+		if ($args === []) {
+			return [];
+		}
+
+		$firstArg = $args[0]->value;
+
+		if (!$firstArg instanceof String_) {
+			return [];
+		}
+
+		$length = strlen($firstArg->value);
+
+		if ($length <= self::MAX_LENGTH) {
+			return [];
+		}
+
+		return [
+			RuleErrorBuilder::message(
+				sprintf(
+					'Post type name "%s" is %d characters long. WordPress limits post type names to %d characters.',
+					$firstArg->value,
+					$length,
+					self::MAX_LENGTH,
+				)
+			)->identifier('apermo.postTypeNameLength')->build(),
+		];
+	}
+}

--- a/src/Rules/PreEncodedJsonDataRule.php
+++ b/src/Rules/PreEncodedJsonDataRule.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Apermo\PhpStanWordPressRules\Rules;
 
+use Apermo\PhpStanWordPressRules\Constants\WordPressStorageFunctions;
 use Apermo\PhpStanWordPressRules\Type\JsonEncodedStringType;
 use PhpParser\Node;
 use PhpParser\Node\Expr\FuncCall;
@@ -11,6 +12,8 @@ use PhpParser\Node\Name;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\Type;
+use PHPStan\Type\UnionType;
 
 /**
  * Flags pre-encoded JSON data passed to WordPress storage functions.
@@ -23,35 +26,6 @@ final class PreEncodedJsonDataRule implements Rule {
 		'json_encode',
 		'wp_json_encode',
 	];
-
-	// phpcs:disable Apermo.DataStructures.ArrayComplexity.TooManyKeysError -- WordPress has many storage functions
-	/**
-	 * WordPress storage functions and the 0-based index of their value parameter.
-	 *
-	 * @var array<string, int>
-	 */
-	private const WP_STORAGE_FUNCTIONS = [
-		'add_option'             => 1,
-		'update_option'          => 1,
-		'add_network_option'     => 2,
-		'update_network_option'  => 2,
-		'add_metadata'           => 3,
-		'update_metadata'        => 3,
-		'update_metadata_by_mid' => 2,
-		'add_post_meta'          => 2,
-		'update_post_meta'       => 2,
-		'add_user_meta'          => 2,
-		'update_user_meta'       => 2,
-		'add_comment_meta'       => 2,
-		'update_comment_meta'    => 2,
-		'add_term_meta'          => 2,
-		'update_term_meta'       => 2,
-		'add_site_meta'          => 2,
-		'update_site_meta'       => 2,
-		'set_transient'          => 1,
-		'set_site_transient'     => 1,
-	];
-	// phpcs:enable Apermo.DataStructures.ArrayComplexity.TooManyKeysError
 
 	/**
 	 * Returns the node type this rule processes.
@@ -76,11 +50,11 @@ final class PreEncodedJsonDataRule implements Rule {
 
 		$function_name = $node->name->toLowerString();
 
-		if ( ! isset( self::WP_STORAGE_FUNCTIONS[ $function_name ] ) ) {
+		if ( ! isset( WordPressStorageFunctions::VALUE_PARAM_INDEX[ $function_name ] ) ) {
 			return [];
 		}
 
-		$value_index = self::WP_STORAGE_FUNCTIONS[ $function_name ];
+		$value_index = WordPressStorageFunctions::VALUE_PARAM_INDEX[ $function_name ];
 		$args        = $node->getArgs();
 
 		if ( ! isset( $args[ $value_index ] ) ) {
@@ -102,7 +76,7 @@ final class PreEncodedJsonDataRule implements Rule {
 
 		$arg_type = $scope->getType( $value_expr );
 
-		if ( $arg_type instanceof JsonEncodedStringType ) {
+		if ( $this->contains_json_encoded_type( $arg_type ) ) {
 			return [
 				RuleErrorBuilder::message(
 					sprintf(
@@ -114,6 +88,28 @@ final class PreEncodedJsonDataRule implements Rule {
 		}
 
 		return [];
+	}
+
+	/**
+	 * Checks if a type is or contains a JsonEncodedStringType.
+	 *
+	 * @param Type $type Type to check.
+	 * @return bool
+	 */
+	private function contains_json_encoded_type( Type $type ): bool {
+		if ( $type instanceof JsonEncodedStringType ) {
+			return true;
+		}
+
+		if ( $type instanceof UnionType ) {
+			foreach ( $type->getTypes() as $inner ) {
+				if ( $inner instanceof JsonEncodedStringType ) {
+					return true;
+				}
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/src/Rules/PreEncodedJsonDataRule.php
+++ b/src/Rules/PreEncodedJsonDataRule.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\PhpStanWordPressRules\Rules;
+
+use Apermo\PhpStanWordPressRules\Type\JsonEncodedStringType;
+use PhpParser\Node;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Name;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * Flags pre-encoded JSON data passed to WordPress storage functions.
+ *
+ * @implements Rule<FuncCall>
+ */
+final class PreEncodedJsonDataRule implements Rule {
+
+	private const BANNED_FUNCTIONS = [
+		'json_encode',
+		'wp_json_encode',
+	];
+
+	// phpcs:disable Apermo.DataStructures.ArrayComplexity.TooManyKeysError -- WordPress has many storage functions
+	/**
+	 * WordPress storage functions and the 0-based index of their value parameter.
+	 *
+	 * @var array<string, int>
+	 */
+	private const WP_STORAGE_FUNCTIONS = [
+		'add_option'             => 1,
+		'update_option'          => 1,
+		'add_network_option'     => 2,
+		'update_network_option'  => 2,
+		'add_metadata'           => 3,
+		'update_metadata'        => 3,
+		'update_metadata_by_mid' => 2,
+		'add_post_meta'          => 2,
+		'update_post_meta'       => 2,
+		'add_user_meta'          => 2,
+		'update_user_meta'       => 2,
+		'add_comment_meta'       => 2,
+		'update_comment_meta'    => 2,
+		'add_term_meta'          => 2,
+		'update_term_meta'       => 2,
+		'add_site_meta'          => 2,
+		'update_site_meta'       => 2,
+		'set_transient'          => 1,
+		'set_site_transient'     => 1,
+	];
+	// phpcs:enable Apermo.DataStructures.ArrayComplexity.TooManyKeysError
+
+	/**
+	 * Returns the node type this rule processes.
+	 *
+	 * @return class-string<FuncCall>
+	 */
+	public function getNodeType(): string {
+		return FuncCall::class;
+	}
+
+	/**
+	 * Processes a function call node.
+	 *
+	 * @param \PhpParser\Node\Expr\FuncCall $node  Function call node.
+	 * @param Scope                         $scope Analysis scope.
+	 * @return list<\PHPStan\Rules\IdentifierRuleError>
+	 */
+	public function processNode( Node $node, Scope $scope ): array { // phpcs:ignore Squiz.Commenting.FunctionComment.IncorrectTypeHint -- Rule interface requires Node
+		if ( ! $node->name instanceof Name ) {
+			return [];
+		}
+
+		$function_name = $node->name->toLowerString();
+
+		if ( ! isset( self::WP_STORAGE_FUNCTIONS[ $function_name ] ) ) {
+			return [];
+		}
+
+		$value_index = self::WP_STORAGE_FUNCTIONS[ $function_name ];
+		$args        = $node->getArgs();
+
+		if ( ! isset( $args[ $value_index ] ) ) {
+			return [];
+		}
+
+		$value_expr = $args[ $value_index ]->value;
+
+		if ( $this->is_direct_json_encode_call( $value_expr ) ) {
+			return [
+				RuleErrorBuilder::message(
+					sprintf(
+						'Do not pass JSON-encoded data to %s(). Pass the raw array/object and let WordPress handle storage.',
+						$function_name,
+					)
+				)->identifier( 'apermo.preEncodedJsonData' )->build(),
+			];
+		}
+
+		$arg_type = $scope->getType( $value_expr );
+
+		if ( $arg_type instanceof JsonEncodedStringType ) {
+			return [
+				RuleErrorBuilder::message(
+					sprintf(
+						'Do not pass JSON-encoded data to %s(). Pass the raw array/object and let WordPress handle storage.',
+						$function_name,
+					)
+				)->identifier( 'apermo.preEncodedJsonData' )->build(),
+			];
+		}
+
+		return [];
+	}
+
+	/**
+	 * Checks if the expression is a direct call to json_encode() or wp_json_encode().
+	 *
+	 * @param Node\Expr $expr Expression to check.
+	 * @return bool
+	 */
+	private function is_direct_json_encode_call( Node\Expr $expr ): bool {
+		if ( ! $expr instanceof FuncCall ) {
+			return false;
+		}
+
+		if ( ! $expr->name instanceof Name ) {
+			return false;
+		}
+
+		return in_array( $expr->name->toLowerString(), self::BANNED_FUNCTIONS, true );
+	}
+}

--- a/src/Rules/PreSerializedDataRule.php
+++ b/src/Rules/PreSerializedDataRule.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Apermo\PhpStanWordPressRules\Rules;
 
+use Apermo\PhpStanWordPressRules\Constants\WordPressStorageFunctions;
 use Apermo\PhpStanWordPressRules\Type\SerializedStringType;
 use PhpParser\Node;
 use PhpParser\Node\Expr\FuncCall;
@@ -23,35 +24,6 @@ final class PreSerializedDataRule implements Rule {
 		'serialize',
 		'maybe_serialize',
 	];
-
-	// phpcs:disable Apermo.DataStructures.ArrayComplexity.TooManyKeysError -- WordPress has many storage functions
-	/**
-	 * WordPress storage functions and the 0-based index of their value parameter.
-	 *
-	 * @var array<string, int>
-	 */
-	private const WP_STORAGE_FUNCTIONS = [
-		'add_option'             => 1,
-		'update_option'          => 1,
-		'add_network_option'     => 2,
-		'update_network_option'  => 2,
-		'add_metadata'           => 3,
-		'update_metadata'        => 3,
-		'update_metadata_by_mid' => 2,
-		'add_post_meta'          => 2,
-		'update_post_meta'       => 2,
-		'add_user_meta'          => 2,
-		'update_user_meta'       => 2,
-		'add_comment_meta'       => 2,
-		'update_comment_meta'    => 2,
-		'add_term_meta'          => 2,
-		'update_term_meta'       => 2,
-		'add_site_meta'          => 2,
-		'update_site_meta'       => 2,
-		'set_transient'          => 1,
-		'set_site_transient'     => 1,
-	];
-	// phpcs:enable Apermo.DataStructures.ArrayComplexity.TooManyKeysError
 
 	/**
 	 * Returns the node type this rule processes.
@@ -76,11 +48,11 @@ final class PreSerializedDataRule implements Rule {
 
 		$function_name = $node->name->toLowerString();
 
-		if ( ! isset( self::WP_STORAGE_FUNCTIONS[ $function_name ] ) ) {
+		if ( ! isset( WordPressStorageFunctions::VALUE_PARAM_INDEX[ $function_name ] ) ) {
 			return [];
 		}
 
-		$value_index = self::WP_STORAGE_FUNCTIONS[ $function_name ];
+		$value_index = WordPressStorageFunctions::VALUE_PARAM_INDEX[ $function_name ];
 		$args        = $node->getArgs();
 
 		if ( ! isset( $args[ $value_index ] ) ) {

--- a/src/Rules/PreSerializedDataRule.php
+++ b/src/Rules/PreSerializedDataRule.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\PhpStanWordPressRules\Rules;
+
+use Apermo\PhpStanWordPressRules\Type\SerializedStringType;
+use PhpParser\Node;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Name;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * Flags pre-serialized data passed to WordPress storage functions.
+ *
+ * @implements Rule<FuncCall>
+ */
+final class PreSerializedDataRule implements Rule {
+
+	private const BANNED_FUNCTIONS = [
+		'serialize',
+		'maybe_serialize',
+	];
+
+	// phpcs:disable Apermo.DataStructures.ArrayComplexity.TooManyKeysError -- WordPress has many storage functions
+	/**
+	 * WordPress storage functions and the 0-based index of their value parameter.
+	 *
+	 * @var array<string, int>
+	 */
+	private const WP_STORAGE_FUNCTIONS = [
+		'add_option'             => 1,
+		'update_option'          => 1,
+		'add_network_option'     => 2,
+		'update_network_option'  => 2,
+		'add_metadata'           => 3,
+		'update_metadata'        => 3,
+		'update_metadata_by_mid' => 2,
+		'add_post_meta'          => 2,
+		'update_post_meta'       => 2,
+		'add_user_meta'          => 2,
+		'update_user_meta'       => 2,
+		'add_comment_meta'       => 2,
+		'update_comment_meta'    => 2,
+		'add_term_meta'          => 2,
+		'update_term_meta'       => 2,
+		'add_site_meta'          => 2,
+		'update_site_meta'       => 2,
+		'set_transient'          => 1,
+		'set_site_transient'     => 1,
+	];
+	// phpcs:enable Apermo.DataStructures.ArrayComplexity.TooManyKeysError
+
+	/**
+	 * Returns the node type this rule processes.
+	 *
+	 * @return class-string<FuncCall>
+	 */
+	public function getNodeType(): string {
+		return FuncCall::class;
+	}
+
+	/**
+	 * Processes a function call node.
+	 *
+	 * @param \PhpParser\Node\Expr\FuncCall $node  Function call node.
+	 * @param Scope                         $scope Analysis scope.
+	 * @return list<\PHPStan\Rules\IdentifierRuleError>
+	 */
+	public function processNode( Node $node, Scope $scope ): array { // phpcs:ignore Squiz.Commenting.FunctionComment.IncorrectTypeHint -- Rule interface requires Node
+		if ( ! $node->name instanceof Name ) {
+			return [];
+		}
+
+		$function_name = $node->name->toLowerString();
+
+		if ( ! isset( self::WP_STORAGE_FUNCTIONS[ $function_name ] ) ) {
+			return [];
+		}
+
+		$value_index = self::WP_STORAGE_FUNCTIONS[ $function_name ];
+		$args        = $node->getArgs();
+
+		if ( ! isset( $args[ $value_index ] ) ) {
+			return [];
+		}
+
+		$value_expr = $args[ $value_index ]->value;
+
+		if ( $this->is_direct_serialize_call( $value_expr ) ) {
+			return [
+				RuleErrorBuilder::message(
+					sprintf(
+						'Do not pass pre-serialized data to %s(). WordPress serializes data automatically.',
+						$function_name,
+					)
+				)->identifier( 'apermo.preSerializedData' )->build(),
+			];
+		}
+
+		$arg_type = $scope->getType( $value_expr );
+
+		if ( $arg_type instanceof SerializedStringType ) {
+			return [
+				RuleErrorBuilder::message(
+					sprintf(
+						'Do not pass pre-serialized data to %s(). WordPress serializes data automatically.',
+						$function_name,
+					)
+				)->identifier( 'apermo.preSerializedData' )->build(),
+			];
+		}
+
+		return [];
+	}
+
+	/**
+	 * Checks if the expression is a direct call to serialize() or maybe_serialize().
+	 *
+	 * @param Node\Expr $expr Expression to check.
+	 * @return bool
+	 */
+	private function is_direct_serialize_call( Node\Expr $expr ): bool {
+		if ( ! $expr instanceof FuncCall ) {
+			return false;
+		}
+
+		if ( ! $expr->name instanceof Name ) {
+			return false;
+		}
+
+		return in_array( $expr->name->toLowerString(), self::BANNED_FUNCTIONS, true );
+	}
+}

--- a/src/Rules/RemoteRequestTimeoutRule.php
+++ b/src/Rules/RemoteRequestTimeoutRule.php
@@ -31,6 +31,7 @@ final class RemoteRequestTimeoutRule implements Rule {
 		'wp_remote_request',
 		'wp_safe_remote_get',
 		'wp_safe_remote_post',
+		'wp_safe_remote_request',
 	];
 
 	/**
@@ -102,6 +103,10 @@ final class RemoteRequestTimeoutRule implements Rule {
 	 */
 	private function has_timeout_key( Array_ $args_array ): bool {
 		foreach ( $args_array->items as $item ) {
+			if ( $item === null ) { // @phpstan-ignore identical.alwaysFalse (Array_::$items can contain null for spread operators)
+				continue;
+			}
+
 			if ( $item->key instanceof String_ && $item->key->value === 'timeout' ) {
 				return true;
 			}

--- a/src/Rules/RemoteRequestTimeoutRule.php
+++ b/src/Rules/RemoteRequestTimeoutRule.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\PhpStanWordPressRules\Rules;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\String_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * Flags WordPress HTTP API calls without an explicit timeout argument.
+ *
+ * @implements Rule<FuncCall>
+ */
+final class RemoteRequestTimeoutRule implements Rule {
+
+	/**
+	 * WordPress HTTP API functions to check.
+	 *
+	 * @var list<string>
+	 */
+	private const HTTP_FUNCTIONS = [
+		'wp_remote_get',
+		'wp_remote_post',
+		'wp_remote_request',
+		'wp_safe_remote_get',
+		'wp_safe_remote_post',
+	];
+
+	/**
+	 * Returns the node type this rule processes.
+	 *
+	 * @return class-string<FuncCall>
+	 */
+	public function getNodeType(): string {
+		return FuncCall::class;
+	}
+
+	/**
+	 * Processes a function call node.
+	 *
+	 * @param \PhpParser\Node\Expr\FuncCall $node  Function call node.
+	 * @param Scope                         $scope Analysis scope.
+	 * @return list<\PHPStan\Rules\IdentifierRuleError>
+	 */
+	public function processNode( Node $node, Scope $scope ): array { // phpcs:ignore Squiz.Commenting.FunctionComment.IncorrectTypeHint -- Rule interface requires Node
+		if ( ! $node->name instanceof Name ) {
+			return [];
+		}
+
+		$function_name = $node->name->toLowerString();
+
+		if ( ! in_array( $function_name, self::HTTP_FUNCTIONS, true ) ) {
+			return [];
+		}
+
+		$args = $node->getArgs();
+
+		if ( count( $args ) < 2 ) {
+			return [
+				RuleErrorBuilder::message(
+					sprintf(
+						'%s() called without an explicit timeout. Pass a timeout in the $args array, e.g. [\'timeout\' => 10].',
+						$function_name,
+					)
+				)->identifier( 'apermo.remoteRequestTimeout' )->build(),
+			];
+		}
+
+		$args_param = $args[1]->value;
+
+		// Skip variable args — can't check statically.
+		if ( ! $args_param instanceof Array_ ) {
+			return [];
+		}
+
+		if ( ! $this->has_timeout_key( $args_param ) ) {
+			return [
+				RuleErrorBuilder::message(
+					sprintf(
+						'%s() called without an explicit timeout. Add a \'timeout\' key to the $args array.',
+						$function_name,
+					)
+				)->identifier( 'apermo.remoteRequestTimeout' )->build(),
+			];
+		}
+
+		return [];
+	}
+
+	/**
+	 * Checks if an array expression contains a timeout key.
+	 *
+	 * @param Array_ $args_array Arguments array expression.
+	 * @return bool
+	 */
+	private function has_timeout_key( Array_ $args_array ): bool {
+		foreach ( $args_array->items as $item ) {
+			if ( $item->key instanceof String_ && $item->key->value === 'timeout' ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+}

--- a/src/Rules/TaxonomyNameLengthRule.php
+++ b/src/Rules/TaxonomyNameLengthRule.php
@@ -13,42 +13,54 @@ use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 
 /**
+ * Flags register_taxonomy() calls where the name exceeds 32 characters.
+ *
  * @implements Rule<FuncCall>
  */
-final class TaxonomyNameLengthRule implements Rule
-{
+final class TaxonomyNameLengthRule implements Rule {
+
 	private const MAX_LENGTH = 32;
 
-	public function getNodeType(): string
-	{
+	/**
+	 * Returns the node type this rule processes.
+	 *
+	 * @return class-string<FuncCall>
+	 */
+	public function getNodeType(): string {
 		return FuncCall::class;
 	}
 
-	public function processNode(Node $node, Scope $scope): array
-	{
-		if (!$node->name instanceof Name) {
+	/**
+	 * Processes a function call node.
+	 *
+	 * @param \PhpParser\Node\Expr\FuncCall $node  Function call node.
+	 * @param Scope                         $scope Analysis scope.
+	 * @return list<\PHPStan\Rules\IdentifierRuleError>
+	 */
+	public function processNode( Node $node, Scope $scope ): array { // phpcs:ignore Squiz.Commenting.FunctionComment.IncorrectTypeHint -- Rule interface requires Node
+		if ( ! $node->name instanceof Name ) {
 			return [];
 		}
 
-		if ($node->name->toLowerString() !== 'register_taxonomy') {
+		if ( $node->name->toLowerString() !== 'register_taxonomy' ) {
 			return [];
 		}
 
 		$args = $node->getArgs();
 
-		if ($args === []) {
+		if ( $args === [] ) {
 			return [];
 		}
 
-		$firstArg = $args[0]->value;
+		$first_arg = $args[0]->value;
 
-		if (!$firstArg instanceof String_) {
+		if ( ! $first_arg instanceof String_ ) {
 			return [];
 		}
 
-		$length = strlen($firstArg->value);
+		$length = strlen( $first_arg->value );
 
-		if ($length <= self::MAX_LENGTH) {
+		if ( $length <= self::MAX_LENGTH ) {
 			return [];
 		}
 
@@ -56,11 +68,11 @@ final class TaxonomyNameLengthRule implements Rule
 			RuleErrorBuilder::message(
 				sprintf(
 					'Taxonomy name "%s" is %d characters long. WordPress limits taxonomy names to %d characters.',
-					$firstArg->value,
+					$first_arg->value,
 					$length,
 					self::MAX_LENGTH,
 				)
-			)->identifier('apermo.taxonomyNameLength')->build(),
+			)->identifier( 'apermo.taxonomyNameLength' )->build(),
 		];
 	}
 }

--- a/src/Rules/TaxonomyNameLengthRule.php
+++ b/src/Rules/TaxonomyNameLengthRule.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\PhpStanWordPressRules\Rules;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\String_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * @implements Rule<FuncCall>
+ */
+final class TaxonomyNameLengthRule implements Rule
+{
+	private const MAX_LENGTH = 32;
+
+	public function getNodeType(): string
+	{
+		return FuncCall::class;
+	}
+
+	public function processNode(Node $node, Scope $scope): array
+	{
+		if (!$node->name instanceof Name) {
+			return [];
+		}
+
+		if ($node->name->toLowerString() !== 'register_taxonomy') {
+			return [];
+		}
+
+		$args = $node->getArgs();
+
+		if ($args === []) {
+			return [];
+		}
+
+		$firstArg = $args[0]->value;
+
+		if (!$firstArg instanceof String_) {
+			return [];
+		}
+
+		$length = strlen($firstArg->value);
+
+		if ($length <= self::MAX_LENGTH) {
+			return [];
+		}
+
+		return [
+			RuleErrorBuilder::message(
+				sprintf(
+					'Taxonomy name "%s" is %d characters long. WordPress limits taxonomy names to %d characters.',
+					$firstArg->value,
+					$length,
+					self::MAX_LENGTH,
+				)
+			)->identifier('apermo.taxonomyNameLength')->build(),
+		];
+	}
+}

--- a/src/Rules/TransientExpirationRule.php
+++ b/src/Rules/TransientExpirationRule.php
@@ -20,7 +20,7 @@ use PHPStan\Rules\RuleErrorBuilder;
 final class TransientExpirationRule implements Rule {
 
 	private const FUNCTIONS = [
-		'set_transient' => 2,
+		'set_transient'      => 2,
 		'set_site_transient' => 2,
 	];
 

--- a/src/Rules/TransientExpirationRule.php
+++ b/src/Rules/TransientExpirationRule.php
@@ -13,56 +13,68 @@ use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 
 /**
+ * Flags set_transient() and set_site_transient() without an expiration.
+ *
  * @implements Rule<FuncCall>
  */
-final class TransientExpirationRule implements Rule
-{
+final class TransientExpirationRule implements Rule {
+
 	private const FUNCTIONS = [
 		'set_transient' => 2,
 		'set_site_transient' => 2,
 	];
 
-	public function getNodeType(): string
-	{
+	/**
+	 * Returns the node type this rule processes.
+	 *
+	 * @return class-string<FuncCall>
+	 */
+	public function getNodeType(): string {
 		return FuncCall::class;
 	}
 
-	public function processNode(Node $node, Scope $scope): array
-	{
-		if (!$node->name instanceof Name) {
+	/**
+	 * Processes a function call node.
+	 *
+	 * @param \PhpParser\Node\Expr\FuncCall $node  Function call node.
+	 * @param Scope                         $scope Analysis scope.
+	 * @return list<\PHPStan\Rules\IdentifierRuleError>
+	 */
+	public function processNode( Node $node, Scope $scope ): array { // phpcs:ignore Squiz.Commenting.FunctionComment.IncorrectTypeHint -- Rule interface requires Node
+		if ( ! $node->name instanceof Name ) {
 			return [];
 		}
 
-		$functionName = $node->name->toLowerString();
+		$function_name = $node->name->toLowerString();
 
-		if (!isset(self::FUNCTIONS[$functionName])) {
+		if ( ! isset( self::FUNCTIONS[ $function_name ] ) ) {
 			return [];
 		}
 
-		$expirationArgIndex = self::FUNCTIONS[$functionName];
-		$args = $node->getArgs();
+		$expiration_index = self::FUNCTIONS[ $function_name ];
+		$args             = $node->getArgs();
 
-		if (count($args) <= $expirationArgIndex) {
+		if ( count( $args ) <= $expiration_index ) {
 			return [
 				RuleErrorBuilder::message(
 					sprintf(
 						'%s() called without an expiration. Transients without expiration never expire and bloat the options table. Add an expiration or use update_option() instead.',
-						$functionName,
+						$function_name,
 					)
-				)->identifier('apermo.transientExpiration')->build(),
+				)->identifier( 'apermo.transientExpiration' )->build(),
 			];
 		}
 
-		$expirationArg = $args[$expirationArgIndex]->value;
+		$expiration_arg = $args[ $expiration_index ]->value;
 
-		if ($expirationArg instanceof Int_ && $expirationArg->value === 0) {
+		if ( $expiration_arg instanceof Int_ && $expiration_arg->value === 0 ) {
 			return [
 				RuleErrorBuilder::message(
 					sprintf(
 						'%s() called with an expiration of 0, which means it will never expire. Add a positive expiration or use update_option() instead.',
-						$functionName,
+						$function_name,
 					)
-				)->identifier('apermo.transientExpiration')->build(),
+				)->identifier( 'apermo.transientExpiration' )->build(),
 			];
 		}
 

--- a/src/Rules/TransientExpirationRule.php
+++ b/src/Rules/TransientExpirationRule.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\PhpStanWordPressRules\Rules;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\Int_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * @implements Rule<FuncCall>
+ */
+final class TransientExpirationRule implements Rule
+{
+	private const FUNCTIONS = [
+		'set_transient' => 2,
+		'set_site_transient' => 2,
+	];
+
+	public function getNodeType(): string
+	{
+		return FuncCall::class;
+	}
+
+	public function processNode(Node $node, Scope $scope): array
+	{
+		if (!$node->name instanceof Name) {
+			return [];
+		}
+
+		$functionName = $node->name->toLowerString();
+
+		if (!isset(self::FUNCTIONS[$functionName])) {
+			return [];
+		}
+
+		$expirationArgIndex = self::FUNCTIONS[$functionName];
+		$args = $node->getArgs();
+
+		if (count($args) <= $expirationArgIndex) {
+			return [
+				RuleErrorBuilder::message(
+					sprintf(
+						'%s() called without an expiration. Transients without expiration never expire and bloat the options table. Add an expiration or use update_option() instead.',
+						$functionName,
+					)
+				)->identifier('apermo.transientExpiration')->build(),
+			];
+		}
+
+		$expirationArg = $args[$expirationArgIndex]->value;
+
+		if ($expirationArg instanceof Int_ && $expirationArg->value === 0) {
+			return [
+				RuleErrorBuilder::message(
+					sprintf(
+						'%s() called with an expiration of 0, which means it will never expire. Add a positive expiration or use update_option() instead.',
+						$functionName,
+					)
+				)->identifier('apermo.transientExpiration')->build(),
+			];
+		}
+
+		return [];
+	}
+}

--- a/src/Rules/UnsafeUnserializeRule.php
+++ b/src/Rules/UnsafeUnserializeRule.php
@@ -80,6 +80,10 @@ final class UnsafeUnserializeRule implements Rule {
 	 */
 	private function has_allowed_classes_key( Array_ $options_array ): bool {
 		foreach ( $options_array->items as $item ) {
+			if ( $item === null ) { // @phpstan-ignore identical.alwaysFalse (Array_::$items can contain null for spread operators)
+				continue;
+			}
+
 			if ( $item->key instanceof String_ && $item->key->value === 'allowed_classes' ) {
 				return true;
 			}

--- a/src/Rules/UnsafeUnserializeRule.php
+++ b/src/Rules/UnsafeUnserializeRule.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\PhpStanWordPressRules\Rules;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\String_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * Flags unserialize() calls without the allowed_classes restriction.
+ *
+ * @implements Rule<FuncCall>
+ */
+final class UnsafeUnserializeRule implements Rule {
+
+	/**
+	 * Returns the node type this rule processes.
+	 *
+	 * @return class-string<FuncCall>
+	 */
+	public function getNodeType(): string {
+		return FuncCall::class;
+	}
+
+	/**
+	 * Processes a function call node.
+	 *
+	 * @param \PhpParser\Node\Expr\FuncCall $node  Function call node.
+	 * @param Scope                         $scope Analysis scope.
+	 * @return list<\PHPStan\Rules\IdentifierRuleError>
+	 */
+	public function processNode( Node $node, Scope $scope ): array { // phpcs:ignore Squiz.Commenting.FunctionComment.IncorrectTypeHint -- Rule interface requires Node
+		if ( ! $node->name instanceof Name ) {
+			return [];
+		}
+
+		if ( $node->name->toLowerString() !== 'unserialize' ) {
+			return [];
+		}
+
+		$args = $node->getArgs();
+
+		if ( count( $args ) < 2 ) {
+			return [
+				RuleErrorBuilder::message(
+					'unserialize() called without allowed_classes restriction. Use unserialize($data, [\'allowed_classes\' => false]) or json_decode() instead.'
+				)->identifier( 'apermo.unsafeUnserialize' )->build(),
+			];
+		}
+
+		$options_arg = $args[1]->value;
+
+		if ( ! $options_arg instanceof Array_ ) {
+			return [];
+		}
+
+		if ( ! $this->has_allowed_classes_key( $options_arg ) ) {
+			return [
+				RuleErrorBuilder::message(
+					'unserialize() called without allowed_classes restriction. Use unserialize($data, [\'allowed_classes\' => false]) or json_decode() instead.'
+				)->identifier( 'apermo.unsafeUnserialize' )->build(),
+			];
+		}
+
+		return [];
+	}
+
+	/**
+	 * Checks if an array expression contains the allowed_classes key.
+	 *
+	 * @param Array_ $options_array Options array expression.
+	 * @return bool
+	 */
+	private function has_allowed_classes_key( Array_ $options_array ): bool {
+		foreach ( $options_array->items as $item ) {
+			if ( $item->key instanceof String_ && $item->key->value === 'allowed_classes' ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+}

--- a/src/Type/JsonEncodedStringType.php
+++ b/src/Type/JsonEncodedStringType.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\PhpStanWordPressRules\Type;
+
+use PHPStan\Type\StringType;
+use PHPStan\Type\VerbosityLevel;
+
+/**
+ * Branded string type for values produced by json_encode() or wp_json_encode().
+ */
+final class JsonEncodedStringType extends StringType {
+
+	/**
+	 * Describes the type for error messages.
+	 *
+	 * @param VerbosityLevel $level Verbosity level.
+	 * @return string
+	 */
+	public function describe( VerbosityLevel $level ): string {
+		return 'json-encoded-string';
+	}
+}

--- a/src/Type/SerializedStringType.php
+++ b/src/Type/SerializedStringType.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\PhpStanWordPressRules\Type;
+
+use PHPStan\Type\StringType;
+use PHPStan\Type\VerbosityLevel;
+
+/**
+ * Branded string type for values produced by serialize() or maybe_serialize().
+ */
+final class SerializedStringType extends StringType {
+
+	/**
+	 * Describes the type for error messages.
+	 *
+	 * @param VerbosityLevel $level Verbosity level.
+	 * @return string
+	 */
+	public function describe( VerbosityLevel $level ): string {
+		return 'serialized-string';
+	}
+}

--- a/tests/Rules/DisallowQueryPostsRuleTest.php
+++ b/tests/Rules/DisallowQueryPostsRuleTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\PhpStanWordPressRules\Tests\Rules;
+
+use Apermo\PhpStanWordPressRules\Rules\DisallowQueryPostsRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<DisallowQueryPostsRule>
+ */
+final class DisallowQueryPostsRuleTest extends RuleTestCase
+{
+	protected function getRule(): Rule
+	{
+		return new DisallowQueryPostsRule();
+	}
+
+	public function testRule(): void
+	{
+		$this->analyse([__DIR__ . '/../data/disallow-query-posts.php'], [
+			[
+				'Do not use query_posts(). Use WP_Query or get_posts() instead.',
+				6,
+			],
+			[
+				'Do not use query_posts(). Use WP_Query or get_posts() instead.',
+				7,
+			],
+		]);
+	}
+}

--- a/tests/Rules/DisallowQueryPostsRuleTest.php
+++ b/tests/Rules/DisallowQueryPostsRuleTest.php
@@ -9,26 +9,39 @@ use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 
 /**
+ * Tests for DisallowQueryPostsRule.
+ *
  * @extends RuleTestCase<DisallowQueryPostsRule>
  */
-final class DisallowQueryPostsRuleTest extends RuleTestCase
-{
-	protected function getRule(): Rule
-	{
+final class DisallowQueryPostsRuleTest extends RuleTestCase {
+
+	/**
+	 * Creates the rule under test.
+	 *
+	 * @return Rule
+	 */
+	protected function getRule(): Rule {
 		return new DisallowQueryPostsRule();
 	}
 
-	public function testRule(): void
-	{
-		$this->analyse([__DIR__ . '/../data/disallow-query-posts.php'], [
+	/**
+	 * Tests that query_posts() calls are flagged.
+	 *
+	 * @return void
+	 */
+	public function testRule(): void {
+		$this->analyse(
+			[ __DIR__ . '/../data/disallow-query-posts.php' ],
 			[
-				'Do not use query_posts(). Use WP_Query or get_posts() instead.',
-				6,
-			],
-			[
-				'Do not use query_posts(). Use WP_Query or get_posts() instead.',
-				7,
-			],
-		]);
+				[
+					'Do not use query_posts(). Use WP_Query or get_posts() instead.',
+					6,
+				],
+				[
+					'Do not use query_posts(). Use WP_Query or get_posts() instead.',
+					7,
+				],
+			]
+		);
 	}
 }

--- a/tests/Rules/NoBlanketSuppressionRuleTest.php
+++ b/tests/Rules/NoBlanketSuppressionRuleTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\PhpStanWordPressRules\Tests\Rules;
+
+use Apermo\PhpStanWordPressRules\Rules\NoBlanketSuppressionRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * Tests for NoBlanketSuppressionRule.
+ *
+ * @extends RuleTestCase<NoBlanketSuppressionRule>
+ */
+final class NoBlanketSuppressionRuleTest extends RuleTestCase {
+
+	/**
+	 * Creates the rule under test.
+	 *
+	 * @return Rule
+	 */
+	protected function getRule(): Rule {
+		return new NoBlanketSuppressionRule();
+	}
+
+	/**
+	 * Tests that blanket suppressions are flagged.
+	 *
+	 * @return void
+	 */
+	public function testRule(): void {
+		$this->analyse(
+			[ __DIR__ . '/../data/no-blanket-suppression.php' ],
+			[
+				[
+					'Blanket suppression is not allowed. Specify which rules to suppress.',
+					5,
+				],
+				[
+					'Blanket suppression is not allowed. Specify which rules to suppress.',
+					8,
+				],
+				[
+					'Blanket suppression is not allowed. Specify which rules to suppress.',
+					21,
+				],
+				[
+					'Blanket suppression is not allowed. Specify which rules to suppress.',
+					24,
+				],
+				[
+					'Blanket suppression is not allowed. Specify which rules to suppress.',
+					27,
+				],
+				[
+					'No error to ignore is reported on line 28.',
+					28,
+				],
+			]
+		);
+	}
+}

--- a/tests/Rules/NoBlanketSuppressionRuleTest.php
+++ b/tests/Rules/NoBlanketSuppressionRuleTest.php
@@ -57,6 +57,14 @@ final class NoBlanketSuppressionRuleTest extends RuleTestCase {
 					'No error to ignore is reported on line 28.',
 					28,
 				],
+				[
+					'Blanket suppression is not allowed. Specify which rules to suppress.',
+					30,
+				],
+				[
+					'No error with identifier argument.type is reported on line 34.',
+					34,
+				],
 			]
 		);
 	}

--- a/tests/Rules/NoConcatenationInTranslationRuleTest.php
+++ b/tests/Rules/NoConcatenationInTranslationRuleTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\PhpStanWordPressRules\Tests\Rules;
+
+use Apermo\PhpStanWordPressRules\Rules\NoConcatenationInTranslationRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * Tests for NoConcatenationInTranslationRule.
+ *
+ * @extends RuleTestCase<NoConcatenationInTranslationRule>
+ */
+final class NoConcatenationInTranslationRuleTest extends RuleTestCase {
+
+	/**
+	 * Creates the rule under test.
+	 *
+	 * @return Rule
+	 */
+	protected function getRule(): Rule {
+		return new NoConcatenationInTranslationRule();
+	}
+
+	/**
+	 * Tests that concatenation in translation functions is flagged.
+	 *
+	 * @return void
+	 */
+	public function testRule(): void {
+		$this->analyse(
+			[ __DIR__ . '/../data/no-concatenation-in-translation.php' ],
+			[
+				[
+					'Do not concatenate dynamic values in __(). Use sprintf() with a translatable format string instead.',
+					6,
+				],
+				[
+					'Do not concatenate dynamic values in __(). Use sprintf() with a translatable format string instead.',
+					7,
+				],
+				[
+					'Do not concatenate dynamic values in __(). Use sprintf() with a translatable format string instead.',
+					10,
+				],
+				[
+					'Do not concatenate dynamic values in esc_html__(). Use sprintf() with a translatable format string instead.',
+					11,
+				],
+				[
+					'Do not concatenate dynamic values in _e(). Use sprintf() with a translatable format string instead.',
+					14,
+				],
+				[
+					'Do not concatenate dynamic values in _n(). Use sprintf() with a translatable format string instead.',
+					17,
+				],
+				[
+					'Do not concatenate dynamic values in _n(). Use sprintf() with a translatable format string instead.',
+					17,
+				],
+				[
+					'Do not concatenate dynamic values in esc_attr__(). Use sprintf() with a translatable format string instead.',
+					38,
+				],
+				[
+					'Do not concatenate dynamic values in _x(). Use sprintf() with a translatable format string instead.',
+					41,
+				],
+				[
+					'Do not concatenate dynamic values in esc_html_e(). Use sprintf() with a translatable format string instead.',
+					44,
+				],
+				[
+					'Do not concatenate dynamic values in esc_attr_e(). Use sprintf() with a translatable format string instead.',
+					47,
+				],
+				[
+					'Do not concatenate dynamic values in _ex(). Use sprintf() with a translatable format string instead.',
+					50,
+				],
+			]
+		);
+	}
+}

--- a/tests/Rules/NoDynamicCodeExecutionRuleTest.php
+++ b/tests/Rules/NoDynamicCodeExecutionRuleTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\PhpStanWordPressRules\Tests\Rules;
+
+use Apermo\PhpStanWordPressRules\Rules\NoDynamicCodeExecutionRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * Tests for NoDynamicCodeExecutionRule.
+ *
+ * @extends RuleTestCase<NoDynamicCodeExecutionRule>
+ */
+final class NoDynamicCodeExecutionRuleTest extends RuleTestCase {
+
+	/**
+	 * Creates the rule under test.
+	 *
+	 * @return Rule
+	 */
+	protected function getRule(): Rule {
+		return new NoDynamicCodeExecutionRule();
+	}
+
+	/**
+	 * Tests that dynamic code execution functions are flagged.
+	 *
+	 * @return void
+	 */
+	public function testRule(): void {
+		$this->analyse(
+			[ __DIR__ . '/../data/no-dynamic-code-execution.php' ],
+			[
+				[
+					'Do not use create_function(). Use anonymous functions (closures) instead.',
+					9,
+				],
+				[
+					'Do not use assert() with a string argument. It evaluates the string as PHP code. Use an expression instead.',
+					12,
+				],
+				[
+					'Do not use preg_replace() with the /e modifier. Use preg_replace_callback() instead.',
+					15,
+				],
+			]
+		);
+	}
+}

--- a/tests/Rules/NoEvalRuleTest.php
+++ b/tests/Rules/NoEvalRuleTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\PhpStanWordPressRules\Tests\Rules;
+
+use Apermo\PhpStanWordPressRules\Rules\NoEvalRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * Tests for NoEvalRule.
+ *
+ * @extends RuleTestCase<NoEvalRule>
+ */
+final class NoEvalRuleTest extends RuleTestCase {
+
+	/**
+	 * Creates the rule under test.
+	 *
+	 * @return Rule
+	 */
+	protected function getRule(): Rule {
+		return new NoEvalRule();
+	}
+
+	/**
+	 * Tests that eval() is flagged.
+	 *
+	 * @return void
+	 */
+	public function testRule(): void {
+		$this->analyse(
+			[ __DIR__ . '/../data/no-dynamic-code-execution.php' ],
+			[
+				[
+					'Do not use eval(). It executes arbitrary PHP code and enables remote code execution.',
+					6,
+				],
+			]
+		);
+	}
+}

--- a/tests/Rules/NoHtmlDomParsingFuncCallRuleTest.php
+++ b/tests/Rules/NoHtmlDomParsingFuncCallRuleTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\PhpStanWordPressRules\Tests\Rules;
+
+use Apermo\PhpStanWordPressRules\Rules\NoHtmlDomParsingFuncCallRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * Tests for NoHtmlDomParsingFuncCallRule (tidy function calls).
+ *
+ * @extends RuleTestCase<NoHtmlDomParsingFuncCallRule>
+ */
+final class NoHtmlDomParsingFuncCallRuleTest extends RuleTestCase {
+
+	/**
+	 * Creates the rule under test.
+	 *
+	 * @return Rule
+	 */
+	protected function getRule(): Rule {
+		return new NoHtmlDomParsingFuncCallRule();
+	}
+
+	/**
+	 * Tests that tidy function calls are flagged.
+	 *
+	 * @return void
+	 */
+	public function testRule(): void {
+		$this->analyse(
+			[ __DIR__ . '/../data/no-html-dom-parsing.php' ],
+			[
+				[
+					'Do not use tidy_parse_string(). Use WP_HTML_Tag_Processor or WP_HTML_Processor instead.',
+					21,
+				],
+				[
+					'Do not use tidy_parse_file(). Use WP_HTML_Tag_Processor or WP_HTML_Processor instead.',
+					24,
+				],
+			]
+		);
+	}
+}

--- a/tests/Rules/NoHtmlDomParsingNewRuleTest.php
+++ b/tests/Rules/NoHtmlDomParsingNewRuleTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\PhpStanWordPressRules\Tests\Rules;
+
+use Apermo\PhpStanWordPressRules\Rules\NoHtmlDomParsingNewRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * Tests for NoHtmlDomParsingNewRule (Masterminds\HTML5 instantiation).
+ *
+ * @extends RuleTestCase<NoHtmlDomParsingNewRule>
+ */
+final class NoHtmlDomParsingNewRuleTest extends RuleTestCase {
+
+	/**
+	 * Creates the rule under test.
+	 *
+	 * @return Rule
+	 */
+	protected function getRule(): Rule {
+		return new NoHtmlDomParsingNewRule();
+	}
+
+	/**
+	 * Tests that Masterminds\HTML5 instantiation is flagged.
+	 *
+	 * @return void
+	 */
+	public function testRule(): void {
+		$this->analyse(
+			[ __DIR__ . '/../data/no-html-dom-parsing.php' ],
+			[
+				[
+					'Do not use Masterminds\HTML5. Use WP_HTML_Tag_Processor or WP_HTML_Processor instead.',
+					14,
+				],
+			]
+		);
+	}
+}

--- a/tests/Rules/NoHtmlDomParsingRuleTest.php
+++ b/tests/Rules/NoHtmlDomParsingRuleTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\PhpStanWordPressRules\Tests\Rules;
+
+use Apermo\PhpStanWordPressRules\Rules\NoHtmlDomParsingRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * Tests for NoHtmlDomParsingRule (method calls).
+ *
+ * @extends RuleTestCase<NoHtmlDomParsingRule>
+ */
+final class NoHtmlDomParsingRuleTest extends RuleTestCase {
+
+	/**
+	 * Creates the rule under test.
+	 *
+	 * @return Rule
+	 */
+	protected function getRule(): Rule {
+		return new NoHtmlDomParsingRule();
+	}
+
+	/**
+	 * Tests that HTML DOM parsing method calls are flagged.
+	 *
+	 * @return void
+	 */
+	public function testRule(): void {
+		$this->analyse(
+			[ __DIR__ . '/../data/no-html-dom-parsing.php' ],
+			[
+				[
+					'Do not use DOMDocument::loadHTML(). Use WP_HTML_Tag_Processor or WP_HTML_Processor instead.',
+					7,
+				],
+				[
+					'Do not use DOMDocument::loadHTMLFile(). Use WP_HTML_Tag_Processor or WP_HTML_Processor instead.',
+					11,
+				],
+				[
+					'Do not use Tidy::parseString(). Use WP_HTML_Tag_Processor or WP_HTML_Processor instead.',
+					18,
+				],
+			]
+		);
+	}
+}

--- a/tests/Rules/PostTypeNameLengthRuleTest.php
+++ b/tests/Rules/PostTypeNameLengthRuleTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\PhpStanWordPressRules\Tests\Rules;
+
+use Apermo\PhpStanWordPressRules\Rules\PostTypeNameLengthRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<PostTypeNameLengthRule>
+ */
+final class PostTypeNameLengthRuleTest extends RuleTestCase
+{
+	protected function getRule(): Rule
+	{
+		return new PostTypeNameLengthRule();
+	}
+
+	public function testRule(): void
+	{
+		$this->analyse([__DIR__ . '/../data/post-type-name-length.php'], [
+			[
+				'Post type name "custom_portfolio_item" is 21 characters long. WordPress limits post type names to 20 characters.',
+				6,
+			],
+			[
+				'Post type name "my_very_long_custom_type_x" is 26 characters long. WordPress limits post type names to 20 characters.',
+				9,
+			],
+		]);
+	}
+}

--- a/tests/Rules/PostTypeNameLengthRuleTest.php
+++ b/tests/Rules/PostTypeNameLengthRuleTest.php
@@ -9,26 +9,39 @@ use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 
 /**
+ * Tests for PostTypeNameLengthRule.
+ *
  * @extends RuleTestCase<PostTypeNameLengthRule>
  */
-final class PostTypeNameLengthRuleTest extends RuleTestCase
-{
-	protected function getRule(): Rule
-	{
+final class PostTypeNameLengthRuleTest extends RuleTestCase {
+
+	/**
+	 * Creates the rule under test.
+	 *
+	 * @return Rule
+	 */
+	protected function getRule(): Rule {
 		return new PostTypeNameLengthRule();
 	}
 
-	public function testRule(): void
-	{
-		$this->analyse([__DIR__ . '/../data/post-type-name-length.php'], [
+	/**
+	 * Tests that post type names exceeding 20 characters are flagged.
+	 *
+	 * @return void
+	 */
+	public function testRule(): void {
+		$this->analyse(
+			[ __DIR__ . '/../data/post-type-name-length.php' ],
 			[
-				'Post type name "custom_portfolio_item" is 21 characters long. WordPress limits post type names to 20 characters.',
-				6,
-			],
-			[
-				'Post type name "my_very_long_custom_type_x" is 26 characters long. WordPress limits post type names to 20 characters.',
-				9,
-			],
-		]);
+				[
+					'Post type name "custom_portfolio_item" is 21 characters long. WordPress limits post type names to 20 characters.',
+					6,
+				],
+				[
+					'Post type name "my_very_long_custom_type_x" is 26 characters long. WordPress limits post type names to 20 characters.',
+					9,
+				],
+			]
+		);
 	}
 }

--- a/tests/Rules/PreEncodedJsonDataRuleTest.php
+++ b/tests/Rules/PreEncodedJsonDataRuleTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\PhpStanWordPressRules\Tests\Rules;
+
+use Apermo\PhpStanWordPressRules\Rules\PreEncodedJsonDataRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * Tests for PreEncodedJsonDataRule.
+ *
+ * @extends RuleTestCase<PreEncodedJsonDataRule>
+ */
+final class PreEncodedJsonDataRuleTest extends RuleTestCase {
+
+	/**
+	 * Creates the rule under test.
+	 *
+	 * @return Rule
+	 */
+	protected function getRule(): Rule {
+		return new PreEncodedJsonDataRule();
+	}
+
+	/**
+	 * Returns additional PHPStan config files to load.
+	 *
+	 * @return string[]
+	 */
+	public static function getAdditionalConfigFiles(): array {
+		return [ __DIR__ . '/../../rules.neon' ];
+	}
+
+	/**
+	 * Tests that JSON-encoded data passed to WP storage functions is flagged.
+	 *
+	 * @return void
+	 */
+	public function testRule(): void {
+		$this->analyse(
+			[ __DIR__ . '/../data/pre-encoded-json-data.php' ],
+			[
+				[
+					'Do not pass JSON-encoded data to update_option(). Pass the raw array/object and let WordPress handle storage.',
+					6,
+				],
+				[
+					'Do not pass JSON-encoded data to update_post_meta(). Pass the raw array/object and let WordPress handle storage.',
+					7,
+				],
+				[
+					'Do not pass JSON-encoded data to set_transient(). Pass the raw array/object and let WordPress handle storage.',
+					8,
+				],
+				[
+					'Do not pass JSON-encoded data to update_option(). Pass the raw array/object and let WordPress handle storage.',
+					15,
+				],
+			]
+		);
+	}
+}

--- a/tests/Rules/PreSerializedDataRuleTest.php
+++ b/tests/Rules/PreSerializedDataRuleTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\PhpStanWordPressRules\Tests\Rules;
+
+use Apermo\PhpStanWordPressRules\Rules\PreSerializedDataRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * Tests for PreSerializedDataRule.
+ *
+ * @extends RuleTestCase<PreSerializedDataRule>
+ */
+final class PreSerializedDataRuleTest extends RuleTestCase {
+
+	/**
+	 * Creates the rule under test.
+	 *
+	 * @return Rule
+	 */
+	protected function getRule(): Rule {
+		return new PreSerializedDataRule();
+	}
+
+	/**
+	 * Returns additional PHPStan config files to load.
+	 *
+	 * @return string[]
+	 */
+	public static function getAdditionalConfigFiles(): array {
+		return [ __DIR__ . '/../../rules.neon' ];
+	}
+
+	/**
+	 * Tests that pre-serialized data passed to WP storage functions is flagged.
+	 *
+	 * @return void
+	 */
+	public function testRule(): void {
+		$this->analyse(
+			[ __DIR__ . '/../data/pre-serialized-data.php' ],
+			[
+				[
+					'Do not pass pre-serialized data to update_option(). WordPress serializes data automatically.',
+					6,
+				],
+				[
+					'Do not pass pre-serialized data to update_post_meta(). WordPress serializes data automatically.',
+					7,
+				],
+				[
+					'Do not pass pre-serialized data to set_transient(). WordPress serializes data automatically.',
+					8,
+				],
+				[
+					'Do not pass pre-serialized data to update_user_meta(). WordPress serializes data automatically.',
+					12,
+				],
+				[
+					'Do not pass pre-serialized data to update_option(). WordPress serializes data automatically.',
+					15,
+				],
+			]
+		);
+	}
+}

--- a/tests/Rules/RemoteRequestTimeoutRuleTest.php
+++ b/tests/Rules/RemoteRequestTimeoutRuleTest.php
@@ -54,12 +54,16 @@ final class RemoteRequestTimeoutRuleTest extends RuleTestCase {
 					10,
 				],
 				[
+					'wp_safe_remote_request() called without an explicit timeout. Pass a timeout in the $args array, e.g. [\'timeout\' => 10].',
+					11,
+				],
+				[
 					'wp_remote_get() called without an explicit timeout. Add a \'timeout\' key to the $args array.',
-					13,
+					14,
 				],
 				[
 					'wp_remote_post() called without an explicit timeout. Add a \'timeout\' key to the $args array.',
-					14,
+					15,
 				],
 			]
 		);

--- a/tests/Rules/RemoteRequestTimeoutRuleTest.php
+++ b/tests/Rules/RemoteRequestTimeoutRuleTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\PhpStanWordPressRules\Tests\Rules;
+
+use Apermo\PhpStanWordPressRules\Rules\RemoteRequestTimeoutRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * Tests for RemoteRequestTimeoutRule.
+ *
+ * @extends RuleTestCase<RemoteRequestTimeoutRule>
+ */
+final class RemoteRequestTimeoutRuleTest extends RuleTestCase {
+
+	/**
+	 * Creates the rule under test.
+	 *
+	 * @return Rule
+	 */
+	protected function getRule(): Rule {
+		return new RemoteRequestTimeoutRule();
+	}
+
+	/**
+	 * Tests that remote requests without timeout are flagged.
+	 *
+	 * @return void
+	 */
+	public function testRule(): void {
+		$this->analyse(
+			[ __DIR__ . '/../data/remote-request-timeout.php' ],
+			[
+				[
+					'wp_remote_get() called without an explicit timeout. Pass a timeout in the $args array, e.g. [\'timeout\' => 10].',
+					6,
+				],
+				[
+					'wp_remote_post() called without an explicit timeout. Pass a timeout in the $args array, e.g. [\'timeout\' => 10].',
+					7,
+				],
+				[
+					'wp_remote_request() called without an explicit timeout. Pass a timeout in the $args array, e.g. [\'timeout\' => 10].',
+					8,
+				],
+				[
+					'wp_safe_remote_get() called without an explicit timeout. Pass a timeout in the $args array, e.g. [\'timeout\' => 10].',
+					9,
+				],
+				[
+					'wp_safe_remote_post() called without an explicit timeout. Pass a timeout in the $args array, e.g. [\'timeout\' => 10].',
+					10,
+				],
+				[
+					'wp_remote_get() called without an explicit timeout. Add a \'timeout\' key to the $args array.',
+					13,
+				],
+				[
+					'wp_remote_post() called without an explicit timeout. Add a \'timeout\' key to the $args array.',
+					14,
+				],
+			]
+		);
+	}
+}

--- a/tests/Rules/TaxonomyNameLengthRuleTest.php
+++ b/tests/Rules/TaxonomyNameLengthRuleTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\PhpStanWordPressRules\Tests\Rules;
+
+use Apermo\PhpStanWordPressRules\Rules\TaxonomyNameLengthRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<TaxonomyNameLengthRule>
+ */
+final class TaxonomyNameLengthRuleTest extends RuleTestCase
+{
+	protected function getRule(): Rule
+	{
+		return new TaxonomyNameLengthRule();
+	}
+
+	public function testRule(): void
+	{
+		$this->analyse([__DIR__ . '/../data/taxonomy-name-length.php'], [
+			[
+				'Taxonomy name "extremely_long_custom_taxonomy_name_xy" is 38 characters long. WordPress limits taxonomy names to 32 characters.',
+				6,
+			],
+			[
+				'Taxonomy name "my_very_long_custom_taxonomy_tags" is 33 characters long. WordPress limits taxonomy names to 32 characters.',
+				9,
+			],
+		]);
+	}
+}

--- a/tests/Rules/TaxonomyNameLengthRuleTest.php
+++ b/tests/Rules/TaxonomyNameLengthRuleTest.php
@@ -9,26 +9,39 @@ use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 
 /**
+ * Tests for TaxonomyNameLengthRule.
+ *
  * @extends RuleTestCase<TaxonomyNameLengthRule>
  */
-final class TaxonomyNameLengthRuleTest extends RuleTestCase
-{
-	protected function getRule(): Rule
-	{
+final class TaxonomyNameLengthRuleTest extends RuleTestCase {
+
+	/**
+	 * Creates the rule under test.
+	 *
+	 * @return Rule
+	 */
+	protected function getRule(): Rule {
 		return new TaxonomyNameLengthRule();
 	}
 
-	public function testRule(): void
-	{
-		$this->analyse([__DIR__ . '/../data/taxonomy-name-length.php'], [
+	/**
+	 * Tests that taxonomy names exceeding 32 characters are flagged.
+	 *
+	 * @return void
+	 */
+	public function testRule(): void {
+		$this->analyse(
+			[ __DIR__ . '/../data/taxonomy-name-length.php' ],
 			[
-				'Taxonomy name "extremely_long_custom_taxonomy_name_xy" is 38 characters long. WordPress limits taxonomy names to 32 characters.',
-				6,
-			],
-			[
-				'Taxonomy name "my_very_long_custom_taxonomy_tags" is 33 characters long. WordPress limits taxonomy names to 32 characters.',
-				9,
-			],
-		]);
+				[
+					'Taxonomy name "extremely_long_custom_taxonomy_name_xy" is 38 characters long. WordPress limits taxonomy names to 32 characters.',
+					6,
+				],
+				[
+					'Taxonomy name "my_very_long_custom_taxonomy_tags" is 33 characters long. WordPress limits taxonomy names to 32 characters.',
+					9,
+				],
+			]
+		);
 	}
 }

--- a/tests/Rules/TransientExpirationRuleTest.php
+++ b/tests/Rules/TransientExpirationRuleTest.php
@@ -9,30 +9,43 @@ use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 
 /**
+ * Tests for TransientExpirationRule.
+ *
  * @extends RuleTestCase<TransientExpirationRule>
  */
-final class TransientExpirationRuleTest extends RuleTestCase
-{
-	protected function getRule(): Rule
-	{
+final class TransientExpirationRuleTest extends RuleTestCase {
+
+	/**
+	 * Creates the rule under test.
+	 *
+	 * @return Rule
+	 */
+	protected function getRule(): Rule {
 		return new TransientExpirationRule();
 	}
 
-	public function testRule(): void
-	{
-		$this->analyse([__DIR__ . '/../data/transient-expiration.php'], [
+	/**
+	 * Tests that transients without expiration are flagged.
+	 *
+	 * @return void
+	 */
+	public function testRule(): void {
+		$this->analyse(
+			[ __DIR__ . '/../data/transient-expiration.php' ],
 			[
-				'set_transient() called without an expiration. Transients without expiration never expire and bloat the options table. Add an expiration or use update_option() instead.',
-				6,
-			],
-			[
-				'set_site_transient() called without an expiration. Transients without expiration never expire and bloat the options table. Add an expiration or use update_option() instead.',
-				7,
-			],
-			[
-				'set_transient() called with an expiration of 0, which means it will never expire. Add a positive expiration or use update_option() instead.',
-				10,
-			],
-		]);
+				[
+					'set_transient() called without an expiration. Transients without expiration never expire and bloat the options table. Add an expiration or use update_option() instead.',
+					6,
+				],
+				[
+					'set_site_transient() called without an expiration. Transients without expiration never expire and bloat the options table. Add an expiration or use update_option() instead.',
+					7,
+				],
+				[
+					'set_transient() called with an expiration of 0, which means it will never expire. Add a positive expiration or use update_option() instead.',
+					10,
+				],
+			]
+		);
 	}
 }

--- a/tests/Rules/TransientExpirationRuleTest.php
+++ b/tests/Rules/TransientExpirationRuleTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\PhpStanWordPressRules\Tests\Rules;
+
+use Apermo\PhpStanWordPressRules\Rules\TransientExpirationRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<TransientExpirationRule>
+ */
+final class TransientExpirationRuleTest extends RuleTestCase
+{
+	protected function getRule(): Rule
+	{
+		return new TransientExpirationRule();
+	}
+
+	public function testRule(): void
+	{
+		$this->analyse([__DIR__ . '/../data/transient-expiration.php'], [
+			[
+				'set_transient() called without an expiration. Transients without expiration never expire and bloat the options table. Add an expiration or use update_option() instead.',
+				6,
+			],
+			[
+				'set_site_transient() called without an expiration. Transients without expiration never expire and bloat the options table. Add an expiration or use update_option() instead.',
+				7,
+			],
+			[
+				'set_transient() called with an expiration of 0, which means it will never expire. Add a positive expiration or use update_option() instead.',
+				10,
+			],
+		]);
+	}
+}

--- a/tests/Rules/UnsafeUnserializeRuleTest.php
+++ b/tests/Rules/UnsafeUnserializeRuleTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\PhpStanWordPressRules\Tests\Rules;
+
+use Apermo\PhpStanWordPressRules\Rules\UnsafeUnserializeRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * Tests for UnsafeUnserializeRule.
+ *
+ * @extends RuleTestCase<UnsafeUnserializeRule>
+ */
+final class UnsafeUnserializeRuleTest extends RuleTestCase {
+
+	/**
+	 * Creates the rule under test.
+	 *
+	 * @return Rule
+	 */
+	protected function getRule(): Rule {
+		return new UnsafeUnserializeRule();
+	}
+
+	/**
+	 * Tests that unsafe unserialize() calls are flagged.
+	 *
+	 * @return void
+	 */
+	public function testRule(): void {
+		$this->analyse(
+			[ __DIR__ . '/../data/unsafe-unserialize.php' ],
+			[
+				[
+					'unserialize() called without allowed_classes restriction. Use unserialize($data, [\'allowed_classes\' => false]) or json_decode() instead.',
+					6,
+				],
+				[
+					'unserialize() called without allowed_classes restriction. Use unserialize($data, [\'allowed_classes\' => false]) or json_decode() instead.',
+					9,
+				],
+			]
+		);
+	}
+}

--- a/tests/data/disallow-query-posts.php
+++ b/tests/data/disallow-query-posts.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+// Should be flagged
+query_posts('posts_per_page=5');
+query_posts(['post_type' => 'page']);
+
+// Should NOT be flagged
+$query = new WP_Query(['posts_per_page' => 5]);
+$posts = get_posts(['post_type' => 'page']);

--- a/tests/data/no-blanket-suppression.php
+++ b/tests/data/no-blanket-suppression.php
@@ -26,3 +26,9 @@ $g = 7;
 
 // @phpstan-ignore-next-line
 $h = 8;
+
+// @phpstan-ignore
+$i = 9;
+
+// @phpstan-ignore argument.type
+$j = 10;

--- a/tests/data/no-blanket-suppression.php
+++ b/tests/data/no-blanket-suppression.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+// phpcs:disable
+$a = 1;
+
+// phpcs:ignore
+$b = 2;
+
+// phpcs:disable WordPress.Security.EscapeOutput
+$c = 3;
+// phpcs:enable WordPress.Security.EscapeOutput
+
+// phpcs:ignore WordPress.Security.EscapeOutput -- reason
+$d = 4;
+
+// phpcs:enable
+$e = 5;
+
+// phpcs:disable -- just a reason
+$f = 6;
+
+// phpcs:ignore -- just a reason
+$g = 7;
+
+// @phpstan-ignore-next-line
+$h = 8;

--- a/tests/data/no-concatenation-in-translation.php
+++ b/tests/data/no-concatenation-in-translation.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+// Should be flagged — variable concatenation
+echo __('Hello ' . $name, 'my-plugin');
+echo __('You have ' . $count . ' items', 'my-plugin');
+
+// Should be flagged — expression concatenation
+echo __('Total: ' . number_format($total), 'my-plugin');
+echo esc_html__('Welcome, ' . $user->display_name, 'my-plugin');
+
+// Should be flagged — _e with concatenation
+_e('Click ' . '<a href="' . $url . '">here</a>' . ' to continue', 'my-plugin');
+
+// Should be flagged — _n singular and plural
+_n('You have ' . $count . ' item', 'You have ' . $count . ' items', $count, 'my-plugin');
+
+// Should NOT be flagged — pure string literal
+echo __('Hello World', 'my-plugin');
+echo esc_html__('Welcome to our site', 'my-plugin');
+
+// Should NOT be flagged — sprintf wrapper
+echo sprintf(__('Hello %s', 'my-plugin'), $name);
+echo sprintf(__('You have %d items', 'my-plugin'), $count);
+
+// Should NOT be flagged — pure literal concatenation for line length
+echo __(
+	'This is a very long string that is split ' .
+	'across multiple lines for readability',
+	'my-plugin'
+);
+
+// Should NOT be flagged — other functions
+echo 'Hello ' . $name;
+
+// Should be flagged — esc_attr__
+echo esc_attr__('Value: ' . $value, 'my-plugin');
+
+// Should be flagged — _x with context
+echo _x('Hello ' . $name, 'greeting context', 'my-plugin');
+
+// Should be flagged — esc_html_e
+esc_html_e('Welcome, ' . $user_name, 'my-plugin');
+
+// Should be flagged — esc_attr_e
+esc_attr_e('Value: ' . $value, 'my-plugin');
+
+// Should be flagged — _ex
+_ex('Hello ' . $name, 'greeting context', 'my-plugin');

--- a/tests/data/no-dynamic-code-execution.php
+++ b/tests/data/no-dynamic-code-execution.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+// Should be flagged — eval
+eval('echo "hello";');
+
+// Should be flagged — create_function
+$func = create_function('$a', 'return $a * 2;');
+
+// Should be flagged — assert with string
+assert('$x > 0');
+
+// Should be flagged — preg_replace with /e
+preg_replace('/pattern/e', 'strtoupper("$1")', $subject);
+
+// Should NOT be flagged — closure
+$func = function ($a) {
+	return $a * 2;
+};
+
+// Should NOT be flagged — assert with expression
+assert($x > 0);
+
+// Should NOT be flagged — preg_replace without /e
+preg_replace('/pattern/', 'replacement', $subject);
+
+// Should NOT be flagged — preg_replace_callback
+preg_replace_callback('/pattern/', function ($matches) {
+	return strtoupper($matches[1]);
+}, $subject);
+
+// Should NOT be flagged — preg_replace with variable pattern
+preg_replace($pattern, 'replacement', $subject);

--- a/tests/data/no-html-dom-parsing.php
+++ b/tests/data/no-html-dom-parsing.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+// Should be flagged — DOMDocument::loadHTML
+$dom = new DOMDocument();
+$dom->loadHTML('<p>Hello</p>');
+
+// Should be flagged — DOMDocument::loadHTMLFile
+$dom2 = new DOMDocument();
+$dom2->loadHTMLFile('/path/to/file.html');
+
+// Should be flagged — Masterminds\HTML5 instantiation
+$html5 = new Masterminds\HTML5();
+
+// Should be flagged — Tidy::parseString
+$tidy = new Tidy();
+$tidy->parseString('<p>Hello</p>');
+
+// Should be flagged — tidy_parse_string
+tidy_parse_string('<p>Hello</p>');
+
+// Should be flagged — tidy_parse_file
+tidy_parse_file('/path/to/file.html');
+
+// Should NOT be flagged — DOMDocument::loadXML (XML is fine)
+$xml_dom = new DOMDocument();
+$xml_dom->loadXML('<root/>');
+
+// Should NOT be flagged — DOMDocument::load (XML file)
+$xml_dom2 = new DOMDocument();
+$xml_dom2->load('/path/to/file.xml');
+
+// Should NOT be flagged — DOMDocument creation without loadHTML
+$xml_dom3 = new DOMDocument('1.0', 'UTF-8');
+$root = $xml_dom3->createElement('root');
+
+// Should NOT be flagged — WP_HTML_Tag_Processor
+$processor = new WP_HTML_Tag_Processor('<p>Hello</p>');
+
+// Should NOT be flagged — simplexml_load_string
+$xml = simplexml_load_string('<root/>');

--- a/tests/data/post-type-name-length.php
+++ b/tests/data/post-type-name-length.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+// Should be flagged (21 chars)
+register_post_type('custom_portfolio_item', []);
+
+// Should be flagged (26 chars)
+register_post_type('my_very_long_custom_type_x', []);
+
+// Should NOT be flagged (exactly 20 chars)
+register_post_type('custom_product_types', []);
+
+// Should NOT be flagged (short)
+register_post_type('portfolio', []);
+
+// Should NOT be flagged (variable — can't check)
+register_post_type($post_type, []);

--- a/tests/data/pre-encoded-json-data.php
+++ b/tests/data/pre-encoded-json-data.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+// Should be flagged — direct json_encode() as argument
+update_option('my_settings', json_encode($settings));
+update_post_meta($post_id, '_config', json_encode($data));
+set_transient('cache_key', json_encode($response), 3600);
+
+// NOT flagged — json_encode() via variable (PHPStan core overrides our type extension)
+$json = json_encode($user_prefs);
+update_user_meta($user_id, '_prefs', $json);
+
+// Should be flagged — wp_json_encode()
+update_option('key', wp_json_encode($data));
+
+// Should NOT be flagged — raw data
+update_option('my_settings', $settings);
+update_post_meta($post_id, '_config', ['foo' => 'bar']);
+
+// Should NOT be flagged — json_encode() not passed to WP storage
+$json = json_encode($data);
+file_put_contents('/tmp/export.json', $json);

--- a/tests/data/pre-serialized-data.php
+++ b/tests/data/pre-serialized-data.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+// Should be flagged — direct serialize() as argument
+update_option('my_settings', serialize($settings));
+update_post_meta($post_id, '_config', serialize($data));
+set_transient('cache_key', serialize($response), 3600);
+
+// Should be flagged — serialize() via variable
+$serialized = serialize($user_prefs);
+update_user_meta($user_id, '_prefs', $serialized);
+
+// Should be flagged — maybe_serialize() as argument
+update_option('key', maybe_serialize($data));
+
+// Should NOT be flagged — raw data
+update_option('my_settings', $settings);
+update_post_meta($post_id, '_config', ['foo' => 'bar']);
+set_transient('cache_key', $response, 3600);
+
+// Should NOT be flagged — serialize() not passed to WP storage
+$encoded = serialize($debug_info);
+file_put_contents('/tmp/debug.dat', $encoded);

--- a/tests/data/remote-request-timeout.php
+++ b/tests/data/remote-request-timeout.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+// Should be flagged — no args
+$response = wp_remote_get($url);
+$response = wp_remote_post($url);
+$response = wp_remote_request($url);
+$response = wp_safe_remote_get($url);
+$response = wp_safe_remote_post($url);
+
+// Should be flagged — args without timeout
+$response = wp_remote_get($url, ['headers' => ['Accept' => 'application/json']]);
+$response = wp_remote_post($url, ['body' => $data]);
+
+// Should NOT be flagged — timeout set
+$response = wp_remote_get($url, ['timeout' => 10]);
+$response = wp_remote_post($url, ['body' => $data, 'timeout' => 15]);
+$response = wp_remote_request($url, ['method' => 'PUT', 'timeout' => 5]);
+$response = wp_safe_remote_get($url, ['timeout' => 10]);
+$response = wp_safe_remote_post($url, ['timeout' => 10]);
+
+// Should NOT be flagged — variable args
+$response = wp_remote_get($url, $args);

--- a/tests/data/remote-request-timeout.php
+++ b/tests/data/remote-request-timeout.php
@@ -8,6 +8,7 @@ $response = wp_remote_post($url);
 $response = wp_remote_request($url);
 $response = wp_safe_remote_get($url);
 $response = wp_safe_remote_post($url);
+$response = wp_safe_remote_request($url);
 
 // Should be flagged — args without timeout
 $response = wp_remote_get($url, ['headers' => ['Accept' => 'application/json']]);
@@ -19,6 +20,7 @@ $response = wp_remote_post($url, ['body' => $data, 'timeout' => 15]);
 $response = wp_remote_request($url, ['method' => 'PUT', 'timeout' => 5]);
 $response = wp_safe_remote_get($url, ['timeout' => 10]);
 $response = wp_safe_remote_post($url, ['timeout' => 10]);
+$response = wp_safe_remote_request($url, ['timeout' => 10]);
 
 // Should NOT be flagged — variable args
 $response = wp_remote_get($url, $args);

--- a/tests/data/taxonomy-name-length.php
+++ b/tests/data/taxonomy-name-length.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+// Should be flagged (38 chars)
+register_taxonomy('extremely_long_custom_taxonomy_name_xy', 'post', []);
+
+// Should be flagged (33 chars)
+register_taxonomy('my_very_long_custom_taxonomy_tags', 'post', []);
+
+// Should NOT be flagged (exactly 32 chars)
+register_taxonomy('a_taxonomy_exactly_32_characters', 'post', []);
+
+// Should NOT be flagged (short)
+register_taxonomy('product_category', 'product', []);
+
+// Should NOT be flagged (variable — can't check)
+register_taxonomy($taxonomy, 'post', []);

--- a/tests/data/transient-expiration.php
+++ b/tests/data/transient-expiration.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+// Should be flagged — missing expiration
+set_transient('my_cache', $data);
+set_site_transient('my_cache', $data);
+
+// Should be flagged — explicit zero
+set_transient('my_cache', $data, 0);
+
+// Should NOT be flagged — positive integer
+set_transient('my_cache', $data, 3600);
+set_site_transient('my_cache', $data, 86400);
+
+// Should NOT be flagged — variable expiration
+set_transient('my_cache', $data, $expiration);
+
+// Should NOT be flagged — constant
+set_transient('my_cache', $data, HOUR_IN_SECONDS);

--- a/tests/data/unsafe-unserialize.php
+++ b/tests/data/unsafe-unserialize.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+// Should be flagged — no second argument
+$data = unserialize($input);
+
+// Should be flagged — empty options array
+$data = unserialize($input, []);
+
+// Should NOT be flagged — allowed_classes => false
+$data = unserialize($input, ['allowed_classes' => false]);
+
+// Should NOT be flagged — allowed_classes with specific classes
+$data = unserialize($input, ['allowed_classes' => [stdClass::class]]);
+
+// Should NOT be flagged — variable options
+$data = unserialize($input, $options);
+
+// Should NOT be flagged — json_decode
+$data = json_decode($input, true);


### PR DESCRIPTION
## Summary

- Bundle third-party PHPStan extensions (strict-rules, deprecation-rules, phpstan-wordpress, phpstan-no-private) as direct dependencies
- Add 13 custom PHPStan rules covering WordPress API misuse, security, i18n, performance, and code quality

## Rules added

| Rule | Category | What it detects |
|------|----------|-----------------|
| DisallowQueryPostsRule | wp-api | `query_posts()` usage |
| PostTypeNameLengthRule | wp-api | `register_post_type()` name > 20 chars |
| TaxonomyNameLengthRule | wp-api | `register_taxonomy()` name > 32 chars |
| TransientExpirationRule | wp-api | `set_transient()` without expiration |
| PreSerializedDataRule | data-integrity | Pre-serialized data in WP storage functions |
| PreEncodedJsonDataRule | data-integrity | Pre-encoded JSON in WP storage functions |
| NoDynamicCodeExecutionRule | security | `create_function()`, `assert()` with string, `preg_replace()` with `/e` |
| NoEvalRule | security | `eval()` usage |
| UnsafeUnserializeRule | security | `unserialize()` without `allowed_classes` |
| RemoteRequestTimeoutRule | wp-api | `wp_remote_*` without explicit timeout |
| NoHtmlDomParsing* (3 rules) | code-quality | `DOMDocument::loadHTML`, tidy functions, Masterminds\HTML5 |
| NoConcatenationInTranslationRule | i18n | String concatenation inside `__()`, `_e()`, etc. |
| NoBlanketSuppressionRule | code-quality | `phpcs:disable`/`phpcs:ignore`/`@phpstan-ignore` without specific rules |

## Test plan

- [x] `composer test` — 15 tests, 15 assertions passing
- [x] `composer analyse` — PHPStan level 6 with strict rules, no errors
- [x] `composer cs` — PHPCS clean

Closes #1, closes #2, closes #3, closes #4, closes #5, closes #6, closes #7, closes #16, closes #18, closes #19, closes #21, closes #22, closes #25