### PR TITLE
refactor: use szepeviktor HookDocBlock and RuleLevelHelper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - Unreleased
+
+### Changed
+
+- AbstractHookDocParamMismatchRule: use szepeviktor `HookDocBlock` and `RuleLevelHelper`
+  for PHPDoc resolution and type checking instead of a custom implementation
+
+### Removed
+
+- `PhpDocTypeResolver`: replaced by szepeviktor's `HookDocBlock`
+- `FilterReturnTypeExtension`: redundant with szepeviktor's
+  `ApplyFiltersDynamicFunctionReturnTypeExtension`
+
 ## [0.3.0] - 2026-03-07
 
 ### Added

--- a/src/Rules/AbstractHookDocParamMismatchRule.php
+++ b/src/Rules/AbstractHookDocParamMismatchRule.php
@@ -4,58 +4,36 @@ declare(strict_types=1);
 
 namespace Apermo\PhpStanWordPressRules\Rules;
 
-use PhpParser\Comment\Doc;
 use PhpParser\Node;
-use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Name;
-use PhpParser\Node\Stmt\Expression;
-use PhpParser\Node\Stmt\Return_;
 use PHPStan\Analyser\Scope;
-use PHPStan\PhpDocParser\Ast\Type\ArrayTypeNode;
-use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
-use PHPStan\PhpDocParser\Ast\Type\IntersectionTypeNode;
-use PHPStan\PhpDocParser\Ast\Type\NullableTypeNode;
-use PHPStan\PhpDocParser\Ast\Type\TypeNode;
-use PHPStan\PhpDocParser\Ast\Type\UnionTypeNode;
-use PHPStan\PhpDocParser\Lexer\Lexer;
-use PHPStan\PhpDocParser\Parser\PhpDocParser;
-use PHPStan\PhpDocParser\Parser\TokenIterator;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
-use PHPStan\Type\ArrayType;
-use PHPStan\Type\BooleanType;
-use PHPStan\Type\Constant\ConstantBooleanType;
-use PHPStan\Type\FloatType;
-use PHPStan\Type\IntegerType;
-use PHPStan\Type\MixedType;
-use PHPStan\Type\NullType;
-use PHPStan\Type\ObjectType;
-use PHPStan\Type\ObjectWithoutClassType;
-use PHPStan\Type\StringType;
-use PHPStan\Type\Type;
-use PHPStan\Type\TypeCombinator;
+use PHPStan\Rules\RuleLevelHelper;
 use PHPStan\Type\VerbosityLevel;
-use PHPStan\Type\VoidType;
+use SzepeViktor\PHPStan\WordPress\HookDocBlock;
 
 /**
  * Abstract base for rules that detect @param mismatches in WordPress hook PHPDoc blocks.
  *
- * Subclasses declare which hook functions to analyse by implementing getHookFunctions().
+ * Uses szepeviktor's HookDocBlock for PHPDoc resolution (via HookDocsVisitor) and
+ * RuleLevelHelper for type acceptance checks. Subclasses declare which hook
+ * functions to analyse by implementing getHookFunctions().
  *
- * @implements Rule<\PhpParser\Node\Stmt>
+ * @implements Rule<FuncCall>
  */
 abstract class AbstractHookDocParamMismatchRule implements Rule {
 
 	/**
-	 * Constructs the rule with PHPDoc parsing dependencies.
+	 * Constructs the rule with szepeviktor's hook PHPDoc and type-checking services.
 	 *
-	 * @param PhpDocParser $php_doc_parser PHPDoc parser.
-	 * @param Lexer        $lexer          Lexer for tokenising PHPDoc strings.
+	 * @param HookDocBlock    $hook_doc_block    PHPDoc resolver for hook calls.
+	 * @param RuleLevelHelper $rule_level_helper PHPStan type acceptance helper.
 	 */
 	public function __construct(
-		private readonly PhpDocParser $php_doc_parser,
-		private readonly Lexer $lexer,
+		private readonly HookDocBlock $hook_doc_block,
+		private readonly RuleLevelHelper $rule_level_helper,
 	) {}
 
 	/**
@@ -70,31 +48,25 @@ abstract class AbstractHookDocParamMismatchRule implements Rule {
 	/**
 	 * Returns the node type this rule processes.
 	 *
-	 * @return class-string<\PhpParser\Node\Stmt>
+	 * @return class-string<FuncCall>
 	 */
 	public function getNodeType(): string {
-		return \PhpParser\Node\Stmt::class;
+		return FuncCall::class;
 	}
 
 	/**
-	 * Processes a statement node, looking for hook calls with PHPDoc @param mismatches.
+	 * Processes a function call node, checking for PHPDoc @param mismatches.
 	 *
-	 * @param \PhpParser\Node\Stmt $node  Statement node.
-	 * @param Scope                $scope Analysis scope.
+	 * @param FuncCall $node  Function call node.
+	 * @param Scope    $scope Analysis scope.
 	 * @return list<\PHPStan\Rules\IdentifierRuleError>
 	 */
 	public function processNode( Node $node, Scope $scope ): array { // phpcs:ignore Squiz.Commenting.FunctionComment.IncorrectTypeHint -- Rule interface requires Node
-		$func_call = $this->extract_func_call( $node );
-
-		if ( $func_call === null ) {
+		if ( ! $node->name instanceof Name ) {
 			return [];
 		}
 
-		if ( ! $func_call->name instanceof Name ) {
-			return [];
-		}
-
-		$function_name = $func_call->name->toLowerString();
+		$function_name = $node->name->toLowerString();
 
 		if ( ! in_array( $function_name, $this->getHookFunctions(), true ) ) {
 			return [];
@@ -105,27 +77,27 @@ abstract class AbstractHookDocParamMismatchRule implements Rule {
 			return [];
 		}
 
-		$doc_comment = $this->find_doc_comment( $node );
+		$resolved_php_doc = $this->hook_doc_block->getNullableHookDocBlock( $node, $scope );
 
-		if ( $doc_comment === null ) {
+		if ( $resolved_php_doc === null ) {
 			return [];
 		}
 
 		// Skip cross-reference blocks used in WordPress core
 		// (e.g. "/** This action is documented in wp-includes/post.php */").
+		$doc_string = $resolved_php_doc->getPhpDocString();
+
 		if (
-			str_contains( $doc_comment, 'This action is documented in' ) ||
-			str_contains( $doc_comment, 'This filter is documented in' )
+			str_contains( $doc_string, 'This action is documented in' ) ||
+			str_contains( $doc_string, 'This filter is documented in' )
 		) {
 			return [];
 		}
 
-		$tokens     = new TokenIterator( $this->lexer->tokenize( $doc_comment ) );
-		$php_doc    = $this->php_doc_parser->parse( $tokens );
-		$param_tags = $php_doc->getParamTagValues();
+		$param_tags = $resolved_php_doc->getParamTags();
 
 		// First arg is the hook name string — skip it.
-		$hook_args = array_slice( $func_call->getArgs(), 1 );
+		$hook_args = array_slice( $node->getArgs(), 1 );
 
 		// Skip if any argument is unpacked — static count cannot be determined.
 		foreach ( $hook_args as $arg ) {
@@ -153,12 +125,15 @@ abstract class AbstractHookDocParamMismatchRule implements Rule {
 		}
 
 		$errors = [];
+		$param_tags_indexed = array_values( $param_tags );
 
 		foreach ( $hook_args as $index => $arg ) {
-			$declared_type = $this->resolve_type_node( $param_tags[ $index ]->type );
+			$declared_type = $param_tags_indexed[ $index ]->getType();
 			$actual_type   = $scope->getType( $arg->value );
 
-			if ( $declared_type->isSuperTypeOf( $actual_type )->no() ) {
+			$accepted = $this->rule_level_helper->accepts( $declared_type, $actual_type, $scope->isDeclareStrictTypes() );
+
+			if ( ! $accepted->result ) {
 				$errors[] = RuleErrorBuilder::message(
 					sprintf(
 						'%s() @param #%d declares type %s but %s is passed.',
@@ -172,105 +147,5 @@ abstract class AbstractHookDocParamMismatchRule implements Rule {
 		}
 
 		return $errors;
-	}
-
-	/**
-	 * Extracts a FuncCall from the statement contexts where apply_filters / do_action appear:
-	 *   - standalone:  apply_filters(...)
-	 *   - assignment:  $x = apply_filters(...)
-	 *   - return:      return apply_filters(...)
-	 *
-	 * Doc comments are attached to the statement node in all three cases.
-	 *
-	 * @param Node $node Statement node.
-	 * @return FuncCall|null
-	 */
-	private function extract_func_call( Node $node ): ?FuncCall {
-		if ( $node instanceof Expression ) {
-			if ( $node->expr instanceof FuncCall ) {
-				return $node->expr;
-			}
-
-			if ( $node->expr instanceof Assign && $node->expr->expr instanceof FuncCall ) {
-				return $node->expr->expr;
-			}
-
-			return null;
-		}
-
-		if ( $node instanceof Return_ && $node->expr instanceof FuncCall ) {
-			return $node->expr;
-		}
-
-		return null;
-	}
-
-	/**
-	 * Finds the PHPDoc comment attached to the statement node.
-	 *
-	 * @param Node $node Statement node.
-	 * @return string|null
-	 */
-	private function find_doc_comment( Node $node ): ?string {
-		$comments = $node->getAttribute( 'comments', [] );
-
-		// Reverse to pick the doc block closest to (immediately before) the call.
-		foreach ( array_reverse( $comments ) as $comment ) {
-			if ( $comment instanceof Doc ) {
-				return $comment->getText();
-			}
-		}
-
-		return null;
-	}
-
-	/**
-	 * Resolves a PHPDoc TypeNode to a PHPStan Type.
-	 * Returns MixedType for complex or unresolvable types to avoid false positives.
-	 *
-	 * @param TypeNode $type_node PHPDoc type node to resolve.
-	 * @return Type
-	 */
-	private function resolve_type_node( TypeNode $type_node ): Type {
-		if ( $type_node instanceof NullableTypeNode ) {
-			return TypeCombinator::addNull( $this->resolve_type_node( $type_node->type ) );
-		}
-
-		if ( $type_node instanceof UnionTypeNode ) {
-			return TypeCombinator::union(
-				...array_map( [ $this, 'resolve_type_node' ], $type_node->types )
-			);
-		}
-
-		if ( $type_node instanceof IntersectionTypeNode ) {
-			return TypeCombinator::intersect(
-				...array_map( [ $this, 'resolve_type_node' ], $type_node->types )
-			);
-		}
-
-		if ( $type_node instanceof ArrayTypeNode ) {
-			return new ArrayType( new MixedType(), $this->resolve_type_node( $type_node->type ) );
-		}
-
-		if ( ! $type_node instanceof IdentifierTypeNode ) {
-			return new MixedType();
-		}
-
-		$name = ltrim( $type_node->name, '\\' );
-
-		return match ( strtolower( $name ) ) {
-			'int', 'integer'   => new IntegerType(),
-			'string'           => new StringType(),
-			'bool', 'boolean'  => new BooleanType(),
-			'float', 'double'  => new FloatType(),
-			'null'             => new NullType(),
-			'true'             => new ConstantBooleanType( true ),
-			'false'            => new ConstantBooleanType( false ),
-			'void'             => new VoidType(),
-			'array'            => new ArrayType( new MixedType(), new MixedType() ),
-			'object'           => new ObjectWithoutClassType(),
-			'mixed'            => new MixedType(),
-			default            => $name !== '' ? new ObjectType( $name ) : new MixedType(),
-		};
 	}
 }

--- a/tests/Rules/ActionDocParamMismatchRuleTest.php
+++ b/tests/Rules/ActionDocParamMismatchRuleTest.php
@@ -31,7 +31,8 @@ final class ActionDocParamMismatchRuleTest extends RuleTestCase {
 	}
 
 	/**
-	 * Loads rules.neon so HookDocsVisitor is registered during fixture analysis.
+	 * Loads phpstan-szepeviktor-services.neon (HookDocBlock + HookDocsVisitor)
+	 * and rules.neon for the full DI context needed by the rule under test.
 	 *
 	 * @return string[]
 	 */

--- a/tests/Rules/ActionDocParamMismatchRuleTest.php
+++ b/tests/Rules/ActionDocParamMismatchRuleTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace Apermo\PhpStanWordPressRules\Tests\Rules;
 
 use Apermo\PhpStanWordPressRules\Rules\ActionDocParamMismatchRule;
-use PHPStan\PhpDocParser\Lexer\Lexer;
-use PHPStan\PhpDocParser\Parser\PhpDocParser;
 use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleLevelHelper;
 use PHPStan\Testing\RuleTestCase;
+use PHPStan\Type\FileTypeMapper;
+use SzepeViktor\PHPStan\WordPress\HookDocBlock;
 
 /**
  * Tests for ActionDocParamMismatchRule.
@@ -24,9 +25,21 @@ final class ActionDocParamMismatchRuleTest extends RuleTestCase {
 	 */
 	protected function getRule(): Rule {
 		return new ActionDocParamMismatchRule(
-			self::getContainer()->getByType( PhpDocParser::class ),
-			self::getContainer()->getByType( Lexer::class ),
+			new HookDocBlock( self::getContainer()->getByType( FileTypeMapper::class ) ),
+			self::getContainer()->getByType( RuleLevelHelper::class ),
 		);
+	}
+
+	/**
+	 * Loads rules.neon so HookDocsVisitor is registered during fixture analysis.
+	 *
+	 * @return string[]
+	 */
+	public static function getAdditionalConfigFiles(): array {
+		return [
+			__DIR__ . '/../../rules.neon',
+			__DIR__ . '/../phpstan-szepeviktor-services.neon',
+		];
 	}
 
 	/**

--- a/tests/Rules/FilterDocParamMismatchRuleTest.php
+++ b/tests/Rules/FilterDocParamMismatchRuleTest.php
@@ -31,7 +31,8 @@ final class FilterDocParamMismatchRuleTest extends RuleTestCase {
 	}
 
 	/**
-	 * Loads rules.neon so HookDocsVisitor is registered during fixture analysis.
+	 * Loads phpstan-szepeviktor-services.neon (HookDocBlock + HookDocsVisitor)
+	 * and rules.neon for the full DI context needed by the rule under test.
 	 *
 	 * @return string[]
 	 */

--- a/tests/Rules/FilterDocParamMismatchRuleTest.php
+++ b/tests/Rules/FilterDocParamMismatchRuleTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace Apermo\PhpStanWordPressRules\Tests\Rules;
 
 use Apermo\PhpStanWordPressRules\Rules\FilterDocParamMismatchRule;
-use PHPStan\PhpDocParser\Lexer\Lexer;
-use PHPStan\PhpDocParser\Parser\PhpDocParser;
 use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleLevelHelper;
 use PHPStan\Testing\RuleTestCase;
+use PHPStan\Type\FileTypeMapper;
+use SzepeViktor\PHPStan\WordPress\HookDocBlock;
 
 /**
  * Tests for FilterDocParamMismatchRule.
@@ -24,9 +25,21 @@ final class FilterDocParamMismatchRuleTest extends RuleTestCase {
 	 */
 	protected function getRule(): Rule {
 		return new FilterDocParamMismatchRule(
-			self::getContainer()->getByType( PhpDocParser::class ),
-			self::getContainer()->getByType( Lexer::class ),
+			new HookDocBlock( self::getContainer()->getByType( FileTypeMapper::class ) ),
+			self::getContainer()->getByType( RuleLevelHelper::class ),
 		);
+	}
+
+	/**
+	 * Loads rules.neon so HookDocsVisitor is registered during fixture analysis.
+	 *
+	 * @return string[]
+	 */
+	public static function getAdditionalConfigFiles(): array {
+		return [
+			__DIR__ . '/../../rules.neon',
+			__DIR__ . '/../phpstan-szepeviktor-services.neon',
+		];
 	}
 
 	/**

--- a/tests/Rules/PreEncodedJsonDataRuleTest.php
+++ b/tests/Rules/PreEncodedJsonDataRuleTest.php
@@ -30,7 +30,7 @@ final class PreEncodedJsonDataRuleTest extends RuleTestCase {
 	 * @return string[]
 	 */
 	public static function getAdditionalConfigFiles(): array {
-		return [ __DIR__ . '/../../rules.neon' ];
+		return [ __DIR__ . '/../phpstan-type-extensions.neon' ];
 	}
 
 	/**

--- a/tests/Rules/PreSerializedDataRuleTest.php
+++ b/tests/Rules/PreSerializedDataRuleTest.php
@@ -30,7 +30,7 @@ final class PreSerializedDataRuleTest extends RuleTestCase {
 	 * @return string[]
 	 */
 	public static function getAdditionalConfigFiles(): array {
-		return [ __DIR__ . '/../../rules.neon' ];
+		return [ __DIR__ . '/../phpstan-type-extensions.neon' ];
 	}
 
 	/**

--- a/tests/phpstan-szepeviktor-services.neon
+++ b/tests/phpstan-szepeviktor-services.neon
@@ -1,0 +1,7 @@
+services:
+    -
+        class: SzepeViktor\PHPStan\WordPress\HookDocBlock
+    -
+        class: SzepeViktor\PHPStan\WordPress\HookDocsVisitor
+        tags:
+            - phpstan.parser.richParserNodeVisitor

--- a/tests/phpstan-type-extensions.neon
+++ b/tests/phpstan-type-extensions.neon
@@ -1,0 +1,9 @@
+services:
+    -
+        class: Apermo\PhpStanWordPressRules\Extensions\SerializeReturnTypeExtension
+        tags:
+            - phpstan.broker.dynamicFunctionReturnTypeExtension
+    -
+        class: Apermo\PhpStanWordPressRules\Extensions\JsonEncodeReturnTypeExtension
+        tags:
+            - phpstan.broker.dynamicFunctionReturnTypeExtension


### PR DESCRIPTION
## Summary

- Replace custom `PhpDocTypeResolver` with szepeviktor's `HookDocBlock` for PHPDoc resolution in `AbstractHookDocParamMismatchRule`
- Replace manual `isSuperTypeOf` type checks with `RuleLevelHelper::accepts()` for proper PHPStan-level type acceptance
- Delete `FilterReturnTypeExtension` (redundant with szepeviktor's `ApplyFiltersDynamicFunctionReturnTypeExtension`)
- Add `tests/phpstan-szepeviktor-services.neon` to provide `HookDocBlock`/`HookDocsVisitor` in tests without loading the full `extension.neon` (which bootstraps large WordPress stubs and causes OOM)
- Add `tests/phpstan-type-extensions.neon` as a minimal config for serialization/JSON rule tests

## Test plan

- [ ] All 17 tests pass (`composer test`)
- [ ] PHPStan clean (`composer analyse`)
- [ ] PHPCS clean (`composer cs`)