### PR TITLE
chore: bump actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,14 +14,14 @@ jobs:
             matrix:
                 php: ['8.3', '8.4']
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
 
             - uses: shivammathur/setup-php@v2
               with:
                   php-version: ${{ matrix.php }}
                   coverage: ${{ matrix.php == '8.4' && 'pcov' || 'none' }}
 
-            - uses: actions/cache@v4
+            - uses: actions/cache@v5
               with:
                   path: vendor
                   key: composer-${{ matrix.php }}-${{ hashFiles('composer.lock') }}
@@ -45,14 +45,14 @@ jobs:
         name: PHPStan
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
 
             - uses: shivammathur/setup-php@v2
               with:
                   php-version: '8.4'
                   coverage: none
 
-            - uses: actions/cache@v4
+            - uses: actions/cache@v5
               with:
                   path: vendor
                   key: composer-8.4-${{ hashFiles('composer.lock') }}
@@ -65,14 +65,14 @@ jobs:
         name: Coding Standards
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
 
             - uses: shivammathur/setup-php@v2
               with:
                   php-version: '8.4'
                   coverage: none
 
-            - uses: actions/cache@v4
+            - uses: actions/cache@v5
               with:
                   path: vendor
                   key: composer-8.4-${{ hashFiles('composer.lock') }}

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -13,7 +13,7 @@ jobs:
             result: ${{ steps.version.outputs.result }}
             prerelease: ${{ steps.version.outputs.prerelease }}
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
 
             - name: Extract version from CHANGELOG
               id: version
@@ -50,7 +50,7 @@ jobs:
 
             - name: Comment on failure
               if: failure()
-              uses: actions/github-script@v7
+              uses: actions/github-script@v8
               with:
                   script: |
                       github.rest.issues.createComment({

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -15,7 +15,7 @@ jobs:
             contents: write
             pull-requests: write
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
               with:
                   fetch-depth: 0
 
@@ -54,7 +54,7 @@ jobs:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Comment on associated PR
-              uses: actions/github-script@v7
+              uses: actions/github-script@v8
               with:
                   script: |
                       const branch = context.ref.replace('refs/heads/', '');

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
             contents: write
             pull-requests: write
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
               with:
                   fetch-depth: 0
 
@@ -74,7 +74,7 @@ jobs:
 
             - name: Comment on merged PR
               if: steps.version.outputs.skip == 'false'
-              uses: actions/github-script@v7
+              uses: actions/github-script@v8
               with:
                   script: |
                       const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({

--- a/.github/workflows/validate-conventional-commits.yml
+++ b/.github/workflows/validate-conventional-commits.yml
@@ -11,7 +11,7 @@ jobs:
         name: Validate Commit Messages
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
               with:
                   fetch-depth: 0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Bump GitHub Actions off the deprecated Node 20 runtime: `actions/cache`
+  v4→v5, `actions/checkout` v4→v5, `actions/github-script` v7→v8. GitHub
+  forces JavaScript actions onto Node 24 starting 2026-06-16.
+
 ## [0.3.0] - 2026-03-07
 
 ### Added


### PR DESCRIPTION
## Background

GitHub forces JavaScript actions off the deprecated Node 20 runtime starting **2026-06-16**, with full removal on 2026-09-16.

## Changes

- `actions/cache` v4→v5
- `actions/checkout` v4→v5
- `actions/github-script` v7→v8

Each target is the first major of that action on the Node 24 runtime. Documented under `## [Unreleased]` so it ships without forcing a release.

Closes #38